### PR TITLE
FIX: Changed stage at PluginBase to not use the string

### DIFF
--- a/pcdsdevices/epics/areadetector/plugins.py
+++ b/pcdsdevices/epics/areadetector/plugins.py
@@ -60,6 +60,10 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
             ret.update(self.source_plugin.read_configuration())
         return ret
 
+    def stage(self):
+        # Ensure the plugin is enabled. We do not disable it on unstage
+        set_and_wait(self.enable, 1)
+        ADBase.stage(self)
 
 class ImagePlugin(ophyd.plugins.ImagePlugin, PluginBase):
     pass


### PR DESCRIPTION
 but the int value of enable.

At the PCDS version of ADCore the string values of the EnableCallbacks and EnableCallbacks_RBV where changed from Enable -> Enabled and Disable -> Disabled breaking the default stage method at PluginBase on Ophyd.

This fix this issue by using the integer value to set it.