### PR TITLE
Added ImagePlugin as a simulated class and a generic SimDetector

### DIFF
--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -111,9 +111,7 @@ class PIMPulnixDetector(PulnixDetector):
         image : np.ndarray
         	Image array
         """
-        return np.reshape(np.array(self.image2.array_data.value),
-                          (self.cam.size.size_y.value,
-                           self.cam.size.size_x.value))
+        return self.image2.image
     
     @property
     @raise_if_disconnected

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -103,8 +103,7 @@ class PIMPulnixDetector(PulnixDetector):
     @raise_if_disconnected
     def image(self):
         """
-        Returns the image stream reshaped to be the correct size using the size
-        component in cam.
+        Returns the image from image2
 
         Returns
         -------

--- a/pcdsdevices/sim/areadetector/detectors.py
+++ b/pcdsdevices/sim/areadetector/detectors.py
@@ -3,7 +3,8 @@
 ##########
 # Module #
 ##########
-from .cam import PulnixCam
+from .cam import (CamBase, PulnixCam)
+from .plugins import (StatsPlugin, ImagePlugin)
 from ..component import Component
 from ...epics.areadetector import detectors
 
@@ -14,3 +15,28 @@ class DetectorBase(detectors.DetectorBase):
 
 class PulnixDetector(detectors.PulnixDetector, DetectorBase):
     cam = Component(PulnixCam, ":")
+
+class SimDetector(detectors.DetectorBase):
+    """
+    Generic simulated detector that has image, stats and cam components.
+    """
+    cam = Component(CamBase, ":")
+    image = Component(ImagePlugin, ":IMAGE:", read_attrs=["array_data"])
+    stats = Component(StatsPlugin, ":Stats:", read_attrs=['centroid',
+                                                          'mean_value'])
+
+    def __init__(self, prefix, read_attrs=None, *args, **kwargs):
+        if read_attrs is None:
+            read_attrs = ["cam", "image", "stats"]
+        super().__init__(prefix, read_attrs=read_attrs, *args, **kwargs)
+    
+    def centroid_x(self):
+        return self.stats.centroid.x.value
+    
+    def centroid_y(self):
+        return self.stats.centroid.y.value
+
+    @property
+    def centroid(self):
+        return (self.centroid_x, self.centroid_y)
+    

--- a/pcdsdevices/sim/pim.py
+++ b/pcdsdevices/sim/pim.py
@@ -17,16 +17,16 @@ from ophyd.signal import ArrayAttributeSignal
 from .sim import SimDevice
 from .signal import FakeSignal
 from .component import (FormattedComponent, Component)
-from .areadetector.plugins import StatsPlugin
+from .areadetector.plugins import (StatsPlugin, ImagePlugin)
 from .areadetector.detectors import PulnixDetector
 from ..epics import pim
 
 
 class PIMPulnixDetector(pim.PIMPulnixDetector, PulnixDetector):
     proc1 = Component(FakeSignal)
-    image1 = Component(FakeSignal)
-    image2 = Component(FakeSignal)
-    stats1 = Component(StatsPlugin, "Stats1:", read_attrs=['centroid',
+    image1 = Component(ImagePlugin, ":IMAGE1:", read_attrs=['array_data'])
+    image2 = Component(ImagePlugin, ":IMAGE2:", read_attrs=['array_data'])
+    stats1 = Component(StatsPlugin, ":Stats1:", read_attrs=['centroid',
                                                             'mean_value'])
     stats2 = Component(StatsPlugin, ":Stats2:", read_attrs=['centroid',
                                                             'mean_value'])
@@ -50,16 +50,8 @@ class PIMPulnixDetector(pim.PIMPulnixDetector, PulnixDetector):
             self._get_readback_centroid_x() * self._centroid_within_bounds())
         self.stats2._get_readback_centroid_y = lambda **kwargs : (
             self._get_readback_centroid_y() * self._centroid_within_bounds())
-
-    @property
-    def image(self):
-        """
-        Returns a blank image using the correct shape of the camera. Override
-        this if you want spoof images.
-        """
-        return np.zeros((int(self.cam.size.size_y.value), 
-                         int(self.cam.size.size_x.value)), dtype=np.uint8)
-
+        # Override the image size signal
+        
     @property
     def centroid_x(self, **kwargs):
         """
@@ -150,6 +142,7 @@ class PIMPulnixDetector(pim.PIMPulnixDetector, PulnixDetector):
 
     @size.setter
     def size(self, val):
+        self.image2._image = lambda : np.zeros(val)
         self.cam.size.size_x.put(val[0])
         self.cam.size.size_y.put(val[1])
 

--- a/tests/sim/areadetector/test_sim_detectors.py
+++ b/tests/sim/areadetector/test_sim_detectors.py
@@ -8,7 +8,8 @@ from collections import OrderedDict
 # Module #
 ##########
 from pcdsdevices.sim.areadetector.detectors import (DetectorBase, 
-                                                    PulnixDetector)
+                                                    PulnixDetector,
+                                                    SimDetector)
 
 # DetectorBase Tests
 
@@ -37,3 +38,21 @@ def test_PulnixDetector_runs_ophyd_functions():
 def test_PulnixDetector_cam_component_reads():
     pulnix_det = PulnixDetector("TEST")
     assert(isinstance(pulnix_det.cam.read(), OrderedDict))
+
+# SimDetector tests
+
+def test_SimDetector_instantiates():
+    assert(SimDetector("TEST"))
+
+def test_SimDetector_runs_ophyd_functions():
+    pulnix_det = SimDetector("TEST")
+    assert(isinstance(pulnix_det.read(), OrderedDict))
+    assert(isinstance(pulnix_det.describe(), OrderedDict))
+    assert(isinstance(pulnix_det.describe_configuration(), OrderedDict))
+    assert(isinstance(pulnix_det.read_configuration(), OrderedDict))
+
+def test_SimDetector_components_read():
+    pulnix_det = SimDetector("TEST")
+    assert(isinstance(pulnix_det.cam.read(), OrderedDict))
+    assert(isinstance(pulnix_det.image.read(), OrderedDict))
+    assert(isinstance(pulnix_det.stats.read(), OrderedDict))

--- a/tests/sim/areadetector/test_sim_plugins.py
+++ b/tests/sim/areadetector/test_sim_plugins.py
@@ -4,14 +4,17 @@
 # Standard #
 ############
 from collections import OrderedDict
+
 ###############
 # Third Party #
 ###############
 import numpy as np
+
 ##########
 # Module #
 ##########
-from pcdsdevices.sim.areadetector.plugins import (PluginBase, StatsPlugin)
+from pcdsdevices.sim.areadetector.plugins import (PluginBase, StatsPlugin,
+                                                  ImagePlugin)
 
 # PluginBase Tests
 
@@ -28,8 +31,6 @@ def test_PluginBase_runs_ophyd_functions():
 # StatsPlugin Tests
 
 def test_StatsPlugin_instantiates():
-    # import ipdb; ipdb.set_trace()
-
     assert(StatsPlugin("TEST"))
 
 def test_StatsPlugin_runs_ophyd_functions():
@@ -49,3 +50,24 @@ def test_StatsPlugin_noise():
         stats.centroid.x.value, 5, atol=5))
     assert(stats.centroid.y.value != 10 and np.isclose(
         stats.centroid.y.value, 10, atol=10))
+
+def test_ImagePlugin_instantiates():
+    assert(ImagePlugin("TEST"))
+    
+def test_ImagePlugin_runs_ophyd_functions():
+    plugin = ImagePlugin("TEST")
+    assert(isinstance(plugin.read(), OrderedDict))
+    assert(isinstance(plugin.describe(), OrderedDict))
+    assert(isinstance(plugin.describe_configuration(), OrderedDict))
+    assert(isinstance(plugin.read_configuration(), OrderedDict))
+
+def test_ImagePlugin_image_info_is_correct():
+    plugin = ImagePlugin("TEST")
+    test_array = np.zeros((1000,500, 3))
+    plugin._image = lambda : test_array
+    assert(plugin.image.all() == test_array.all())
+    assert(plugin.array_pixels == 1000*500*3)    
+    assert(plugin.array_data.value.all() == test_array.flatten().all())
+    assert(plugin.array_size.height.value == 1000)
+    assert(plugin.array_size.width.value == 500)
+    assert(plugin.array_size.depth.value == 3)


### PR DESCRIPTION
Relatively benign PR. Added a ImagePlugin class to the sim devices so I can have the detectors actually return images for testing psbeam. This PR also fixes all the issues with the image attribute of ImagePlugin not working properly by overriding some ophyd attributes with variants that enforce type casting.