### PR TITLE
ENH: Mirror motors stage to nominal position

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source =
+    pcdsdevices 
+[report]
+omit =
+    #tests
+    */tests/*
+    *test*
+    #versioning
+    .*version.*
+    *_version.py

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -105,6 +105,11 @@ class OMMotor(Device, PositionerBase):
     name : str, optional
         The name of the motor
 
+    nominal_position : float, optional
+        The position believed to be aligned to the beam. This can either be the
+        previously aligned position, or the position given by the alignment
+        team
+
     parent : instance or None, optional
         The instance of the parent device, if applicable
 
@@ -140,8 +145,9 @@ class OMMotor(Device, PositionerBase):
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
                  name=None, parent=None, settle_time=0, tolerance=0.01,
-                 use_limits=True, **kwargs):
-
+                 use_limits=True, nominal_position=None, **kwargs):
+        
+        self.nominal_position = nominal_position
         if read_attrs is None:
             read_attrs = ['user_readback']
         if configuration_attrs is None:
@@ -427,6 +433,18 @@ class OMMotor(Device, PositionerBase):
         limits : tuple
         """
         return (self.low_limit, self.high_limit)
+
+
+    def stage(self):
+        """
+        Stage the OMS motor to nominal position
+        """
+        if self.nominal_position is not None:
+            logger.debug("Moving {} to nominal aligned position"
+                         "".format(self.name))
+            self.move(self.nominal_position, wait=True)
+        super().stage()
+
 
     @limits.setter
     def limits(self, value):

--- a/tests/sim/test_sim_mirror.py
+++ b/tests/sim/test_sim_mirror.py
@@ -28,6 +28,11 @@ def test_OMMotor_runs_ophyd_functions():
     assert(isinstance(ommotor.describe_configuration(), OrderedDict))
     assert(isinstance(ommotor.read_configuration(), OrderedDict))
 
+def test_OMMotor_stages():
+    ommotor = OMMotor("TEST", nominal_position=42.0)
+    ommotor.stage()
+    assert ommotor.position == 42.0
+
 def test_OMMotor_moves_properly():
     ommotor = OMMotor("TEST")
     status = ommotor.move(10)


### PR DESCRIPTION
Stage any `OMMotor` that has a `nominal_position`. We will have to put an `@stage_decorator` on before this does anything for S.O.P

Closes: #8 