### PR TITLE
ENH: Pim stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build
 htmlcov
 .coverage
 .cache
+
+*.egg-info

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -388,6 +388,14 @@ class PIMMotor(Device):
         """
         return self.blocking
 
+    def stage(self):
+        self.move_in(wait=True)
+        return super().stage()
+
+    def unstage(self):
+        self.move_out(wait=False)
+        return super().unstage()
+
 
 class PIM(PIMMotor):
     """

--- a/tests/sim/test_sim_pim.py
+++ b/tests/sim/test_sim_pim.py
@@ -174,3 +174,12 @@ def test_PIM_noise():
     status = pim.move("IN")
     assert(status.success)
     assert(pim.sim_y.value != 5 and np.isclose(pim.sim_y.value, 5, atol=0.1))
+
+def test_PIMMotor_stage():
+    pim = PIMMotor("TEST", pos_in=5)
+    pim.move_out(wait=True)
+    pim.stage()
+    assert(pim.position == "IN")
+    pim.unstage()
+    time.sleep(0.2)
+    assert(pim.position == "OUT")


### PR DESCRIPTION
Have PIMMotor move in on .stage() and out on .unstage() so we can simplify the pswalker code and more generically check for staged detectors in things like the recovery plan. We can stop relying on prep_img_motors (which is a complicated overoptimization) if we just wrap walk_to_pixel with the stage decorator. This will also help us make sure the pims come all the way out at the end of the alignment. Have stage wait for the pim to go in, but don't wait on unstage because these are basically out of the beam in half a second.

Also a small addition to the .gitignore so an egg-info directory won't show as modified.