### PR TITLE
BUG: Bandaid fix for race condition

### DIFF
--- a/pcdsdevices/sim/pim.py
+++ b/pcdsdevices/sim/pim.py
@@ -179,7 +179,7 @@ class PIMMotor(pim.PIMMotor):
         self.noise_type = noise_type
         self.noise_args = noise_args
         self.noise_kwargs = noise_kwargs
-        self._pos._get_readback = lambda : self.pos_d[self.position]
+        self._pos._get_readback = lambda : self.pos_d.get(self.position)
     
     def move(self, position, **kwargs):
         if isinstance(position, str):


### PR DESCRIPTION
Sometimes this lambda function fails because self.position doesn't have a numerical position associated with it in the self.pos_d dictionary. The quick and dirty fix is to use the get function to return None instead of raising the KeyError. I don't think this creates new issues anywhere else and it should fix one of our pswalker race conditions. The bit of code that enters this block for the race condition in sim/signal Signal.put is checking for a TypeError on str + float, and you also get a TypeError on None + float, so we "might" be able to continue on... or we might learn what the next exception is in the race condition chain.