### PR TITLE
ENH: LightInterface and EPICS testing

### DIFF
--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -5,12 +5,13 @@ del get_versions
 #import logging # NOQA
 #logging.basicConfig(level=logging.INFO)
 #logger = logging.getLogger(__name__)
-
+import warnings
 from .device import Device # NOQA
 
 # Let the submodules decide what to push up to the top level
 # Assume ImportError means that we can't use the optional submodule
 try:
     from .epics import * # NOQA
-except ImportError:
-    pass
+except ImportError as e:
+    warnings.warn("epics submodule did not import {} correctly"
+                  "".format(e), RuntimeWarning)

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -24,7 +24,7 @@ class Device(ophyd.Device, metaclass=LightInterface):
         db_info = kwargs.pop("db_info", None)
         if db_info:
             self.db = HappiData(db_info)
-            #Create mandatory attributes from Happi Information
+            #Create mandatory lightpath attributes from Happi Information
             #Placing None as default
             for key in LIGHTPATH_KWARGS:
                 setattr(self, key, kwargs.get(key, None))
@@ -38,7 +38,7 @@ class Device(ophyd.Device, metaclass=LightInterface):
     @property
     def removed(self):
         """
-        Report if the device is currently removed into the beam
+        Report if the device is currently removed from the beam
         """
         raise NotImplementedError
 

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -6,28 +6,55 @@ PCDS Ophyd Device overrides.
 from collections import OrderedDict
 
 import ophyd
+from lightpath import LightInterface
 
 from .component import Component
-
 VALID_OPHYD_KWARGS = ("name", "parent", "prefix", "read_attrs",
                       "configuration_attrs")
 
+LIGHTPATH_KWARGS = ('beamline', 'z')
 
-class Device(ophyd.Device):
+class Device(ophyd.Device, metaclass=LightInterface):
     """
     Subclass of ophyd.Device that soaks up and stores information from the
     happi device database.
     """
+    transmission = 0.0
     def __init__(self, prefix, **kwargs):
         db_info = kwargs.pop("db_info", None)
         if db_info:
             self.db = HappiData(db_info)
+            #Create mandatory attributes from Happi Information
+            #Placing None as default
+            for key in LIGHTPATH_KWARGS:
+                setattr(self, key, kwargs.get(key, None))
             for key in list(kwargs.keys()):
                 # Remove keys in kwargs if they were from the happi import but
                 # they cannot be passed to ophyd.Device
                 if key in db_info and key not in VALID_OPHYD_KWARGS:
                     kwargs.pop(key)
         super().__init__(prefix, **kwargs)
+
+    @property
+    def removed(self):
+        """
+        Report if the device is currently removed into the beam
+        """
+        raise NotImplementedError
+
+    @property
+    def inserted(self):
+        """
+        Report if the device is currently inserted into the beam
+        """
+        raise NotImplementedError
+
+
+    def remove(self, *args, **kwargs):
+        """
+        Remove the device from the beamline
+        """
+        raise NotImplementedError
 
 
 class HappiData:

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -17,7 +17,7 @@ class IPM(IocDevice):
     diode and one for the target. This creates a scalar readback that is also
     available over EPICS.
     """
-    diode = Component(InOutStates, " :DIODE")
+    diode = Component(InOutStates,   ":DIODE")
     target = Component(TargetStates, ":TARGET")
     data = FormattedComponent(EpicsSignalRO, "{self._data}")
 

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -4,6 +4,8 @@ from .iocdevice import IocDevice
 from .state import statesrecord_class, InOutStates
 from .component import Component, FormattedComponent
 from .signal import EpicsSignalRO
+from ophyd.status import wait as status_wait
+
 
 TargetStates = statesrecord_class("TargetStates", ":OUT", ":TARGET1",
                                   ":TARGET2", ":TARGET3", ":TARGET4")
@@ -15,23 +17,29 @@ class IPM(IocDevice):
     diode and one for the target. This creates a scalar readback that is also
     available over EPICS.
     """
-    diode = Component(InOutStates, ":DIODE")
+    diode = Component(InOutStates, " :DIODE")
     target = Component(TargetStates, ":TARGET")
     data = FormattedComponent(EpicsSignalRO, "{self._data}")
 
+    #Default subscriptions
+    SUB_ST_CHG   = 'target_state_changed'
+    _default_sub = SUB_ST_CHG
+    transmission = 0.8 #Completely making up this number :)
+
     def __init__(self, prefix, *, data="", ioc="", name=None, parent=None,
                  read_attrs=None, **kwargs):
+        #Default read attributes
         self._data = data
         if read_attrs is None:
             read_attrs = ["data"]
+
         super().__init__(prefix, ioc=ioc, name=name, parent=parent,
                          read_attrs=read_attrs, **kwargs)
+        #Subscribe to state changes
+        self.target.subscribe(self._target_moved,
+                              event_type=self.target.SUB_RBK_CHG,
+                              run=False)
 
-    def target_out(self):
-        """
-        Move the target to the OUT position.
-        """
-        self.target.value = "OUT"
 
     def target_in(self, target):
         """
@@ -46,14 +54,78 @@ class IPM(IocDevice):
         if 1 <= target <= 4:
             self.target.value = "TARGET{}".format(target)
 
+
+    @property
+    def inserted(self):
+        """
+        Report if the IPIMB is not OUT"
+        """
+        return self.target.value != "OUT"
+
+
+
+    @property
+    def removed(self):
+        """
+        Report if the IPM is inserted
+        """
+        return self.target.value == "OUT"
+
+
+
+    def remove(self, *args, wait=False, **kwargs):
+        """
+        Remove the IPM by going to the `OUT` position
+
+        Parameters
+        ----------
+        wait : bool, optional
+            Wait for the status object to complete the move before returning
+
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used
+
+        settle_time: float, optional
+            Delay after the set() has completed to indicate completion to the
+            caller
+
+        Returns
+        -------
+        status : MoveStatus
+            Status object of the move
+
+        Notes
+        -----
+        Instantiated for `lightpath` compatability
+        """
+        #Set to out
+        status = self.target.state.set("OUT", **kwargs)
+        #Wait on status
+        if wait:
+            status_wait(status)
+        return status
+
+
     def diode_in(self):
         """
         Move the diode to the in position.
         """
         self.diode.value = "IN"
 
+
     def diode_out(self):
         """
         Move the diode to the out position.
         """
         self.diode.value = "OUT"
+
+
+    def _target_moved(self, **kwargs):
+        """
+        Callback when device state has moved
+        """
+        #Avoid duplicate keywords
+        kwargs.pop('sub_type', None)
+        #Run subscriptions
+        self._run_subs(sub_type=self.SUB_ST_CHG, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 git+https://github.com/slaclab/happi.git#egg=happi
+git+https://github.com/slaclab/lightpath.git#egg=lightpath
 ophyd 

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,7 +5,7 @@ import pytest
 if __name__ == '__main__':
     # Show output results from every test function
     # Show the message output for skipped and expected failures
-    args = ['tests', '-v', '-vrxs']
+    args = ['-v', '-vrxs']
 
     # Add extra arguments
     if len(sys.argv) > 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,106 +1,263 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
-import re
-import pytest
-from pcdsdevices import (ImsMotor, GateValve, Slits, Attenuator,
-                         PulsePickerPink, Stopper, PPSStopper, IPM, PIM, 
-                         PIMMotor, PIMPulnixDetector, LODCM, OffsetMirror, 
-                         PIMFee )
-from pcdsdevices.epics.areadetector.detectors import (FeeOpalDetector,
-                                                       PulnixDetector)
+import sys
+import time
+import copy
+import random
+import logging
+import threading
+from functools import wraps
 
-class Params:
-    registry = OrderedDict()
+import epics
+import numpy as np
 
-    def __init__(self, name, cls, prefix, *args, **kwargs):
-        self.cls = cls
-        self.prefix = prefix
-        self.name = name
-        kwargs["name"] = name
-        self.args = args
-        self.kwargs = kwargs
-        self.registry[name] = self
+
+class FakeEpicsPV(object):
+    """
+    Fake EpicsPV that mocks the API `epics.PV`
+
+    Keep in mind this is an incredibly simple implementation, after being
+    intialized as `None` the PV will hold whatever value you `put` to it. This
+    triggers all subscribed callbacks.
+
+    Notes
+    -----
+    A few gotchas to keep in mind when writing tests
+        - Using `@using_fake_epics_pv` is slightly complex when using fixtures.
+          Because some of `ophyd` instantiates Epics PVs lazily it is best
+          practice to have a wrapper around both the fixture and test
+        - A signal that has separate a `_read_pv` and `_write_pv` will only put
+          to the write side, this will not change the readback at all
+        - Calling `set` on a signal launches another thread to actually change
+          the value. This means if you are planning on checking the result of a
+          method that calls `set` underneath, you should put a small `sleep`
+          afterwards to let the thread create itself and get to the point of
+          actually changing the value. The other way around this is to use a
+          `wait` in your method. This will block the main thread until the
+          set_thread catches up. For this to work you need to make sure that
+          `put_complete` is set to `True` on the EpicsSignal you are calling
+          `set` on
+    """
+    _connect_delay = (0.05, 0.1)
+    _update_rate = 0.1
+    _pv_idx = 0
+    auto_monitor = True
+
+    def __init__(self, pvname, form=None,
+                 callback=None, connection_callback=None,
+                 auto_monitor=True, enum_strs=None,
+                 **kwargs):
+
+        self._pvname = pvname
+        self._connection_callback = connection_callback
+        self._form = form
+        self._auto_monitor = auto_monitor
+        self._value = None
+        self._connected = True
+        self._running = True
+        self.enum_strs = enum_strs
+        FakeEpicsPV._pv_idx += 1
+        self._idx = FakeEpicsPV._pv_idx
+
+        self._update = True
+        self._thread = threading.Thread(target=self._update_loop)
+        self._thread.daemon = True
+        self._thread.start()
+
+        self.callbacks = dict()
+        if callback:
+            self.add_callback(callback)
 
     def __del__(self):
-        del self.registry[self.name]
+        self.clear_callbacks()
+        self._running = False
 
-    @classmethod
-    def get(cls, param="name", regex=None):
-        if regex is None:
-            params = list(cls.registry.values())
+    def get_timevars(self):
+        pass
+
+    def get_ctrlvars(self):
+        pass
+
+    @property
+    def connected(self):
+        """
+        PV is connected
+        """
+        return self._connected
+
+
+    def _update_loop(self):
+        """
+        Connect PV and run connection callback
+        """
+        if self._connection_callback is not None:
+            self._connection_callback(pvname=self._pvname, conn=True, pv=self)
+
+        if self._pvname in ('does_not_connect', ):
+            return
+
+        self._connected = True
+
+
+    def wait_for_connection(self, timeout=None):
+        """
+        Wait for PV connection
+        """
+        if self._pvname in ('does_not_connect', ):
+            return False
+
+        while not self._connected:
+            time.sleep(0.05)
+
+        return True
+
+
+    @property
+    def lower_ctrl_limit(self):
+        return 0.
+
+
+    @property
+    def upper_ctrl_limit(self):
+        return 1.
+
+
+    def run_callbacks(self):
+        """
+        Run all stored callbacks
+        """
+        for index in sorted(list(self.callbacks.keys())):
+            if not self._running:
+                break
+            self.run_callback(index)
+
+
+    def run_callback(self, index):
+        """
+        Run an individual callback
+        """
+        fcn = self.callbacks[index]
+        kwd = dict(pvname=self._pvname,
+                   count=1,
+                   nelm=1,
+                   type=None,
+                   typefull=None,
+                   ftype=None,
+                   access='rw',
+                   chid=self._idx,
+                   read_access=True,
+                   write_access=True,
+                   value=self.value,
+                   )
+        kwd['cb_info'] = (index, self)
+        if hasattr(fcn, '__call__'):
+            fcn(**kwd)
+
+
+    def add_callback(self, callback=None, index=None, run_now=False,
+                     with_ctrlvars=True):
+        """
+        Add a callback to the PV
+        """
+        if hasattr(callback, '__call__'):
+            if index is None:
+                index = 1
+                if len(self.callbacks) > 0:
+                    index = 1 + max(self.callbacks.keys())
+            self.callbacks[index] = callback
+        if run_now:
+            if self.connected:
+                self.run_callback(index)
+        return index
+
+    def remove_callback(self, index=None):
+        if index in self.callbacks:
+            self.callbacks.pop(index)
+
+    def clear_callbacks(self):
+        self.callbacks.clear()
+
+    @property
+    def precision(self):
+        return 0
+
+    @property
+    def units(self):
+        return str(None)
+
+    @property
+    def timestamp(self):
+        """
+        Simulated timestamp
+        """
+        return time.time()
+
+    @property
+    def pvname(self):
+        """
+        Name of PV
+        """
+        return self._pvname
+
+    @property
+    def value(self):
+        """
+        Last set value
+        """
+        return self._value
+
+    def __repr__(self):
+        return '<FakePV %s value=%s>' % (self._pvname, self.value)
+
+    def get(self, as_string=False, use_numpy=False,
+            use_monitor=False):
+        """
+        Simulate and EPICS caget
+        """
+        if as_string:
+            #Return list of enums
+            if isinstance(self.value, list):
+                if self.enum_strs:
+                    return [self.enum_strs[_] for _ in self.value]
+                return list(self.value)
+            #Return single string
+            if isinstance(self.value, str):
+                return self.value
+            #Return single enum
+            else:
+                if self.enum_strs:
+                    return self.enum_strs[self.value]
+                return str(self.value)
+        #Return numpy array
+        elif use_numpy:
+            return np.array(self.value)
+        #Otherwise return the value as is
         else:
-            params = []
-            for param_obj in cls.registry.values():
-                if param == "cls":
-                    string = param_obj.cls.__name__
-                else:
-                    try:
-                        attr = getattr(param_obj, param)
-                    except AttributeError:
-                        attr = param_obj.kwargs[param]
-                    string = str(attr)
-                if re.search(string, regex):
-                    params.append(param_obj)
-        return params
-
-Params("xcs_ims_usr32", ImsMotor, "XCS:USR:MMS:32", ioc="IOC:XCS:USR:DUMB:IMS")
-Params("xcs_lam_valve1", GateValve, "XCS:LAM:VGC:01", ioc="XCS:R51:IOC:39")
-Params("xcs_slits6", Slits, "XCS:SB2:DS:JAWS", ioc="IOC:XCS:SB2:SLITS:IMS")
-Params("pp_pink", PulsePickerPink, "XCS:SB2:MMS:09", states="XCS:SB2:PP:Y",
-       ioc="XCS:IOC:PULSEPICKER:IMS", states_ioc="IOC:XCS:DEVICE:STATES")
-Params("xcs_att", Attenuator, "XCS:ATT", n_filters=10, ioc="IOC:XCS:ATT")
-Params("dg2_stopper", Stopper, "HFX:DG2:STP:01")
-Params("s5_pps_stopper", PPSStopper, "PPS:FEH1:4:S4STPRSUM")
-Params("xcs_ipm", IPM, "XCS:SB2:IPM6", ioc="IOC:XCS:SB2:IPM06:IMS",
-       data="XCS:SB2:IMB:01:SUM")
-Params("xcs_pim", PIM, "XCS:SB2:PIM6")
-Params("xcs_lodcm", LODCM, "XCS:LODCM", ioc="IOC:XCS:LODCM")
-Params("fee_homs", OffsetMirror, "MIRR:FEE1:M1H", 'STEP:M1H')
-Params("det_p3h", FeeOpalDetector, "CAMR:FEE1:913")
-Params("det_dg3", PIMPulnixDetector, "HFX:DG3:CVV:01")
-Params("fee_yag", PIMFee, "CAMR:FEE1:913", prefix_pos="FEE1:P3H", 
-       ioc="IOC:FEE1:PROFILEMON")
-Params("dg3_motor", PIMMotor, "HFX:DG3:PIM")
-Params("dg3_pim", PIM, "HFX:DG3:PIM")
-
-# TODO: add xpp table when xpp comes online
-
-all_params = Params.get()
-all_labels = [p.name for p in all_params]
+            return self.value
 
 
-@pytest.fixture(scope="module",
-                params=all_params,
-                ids=all_labels)
-def all_devices(request):
-    cls = request.param.cls
-    prefix = request.param.prefix
-    args = request.param.args
-    kwargs = request.param.kwargs
-    return cls(prefix, *args, **kwargs)
+    def put(self, value, wait=False, timeout=30.0,
+            use_complete=False, callback=None, callback_data=None):
+        """
+        Simulate a EPICS caput
+        """
+        #Update stored value
+        self._update = False
+        self._value = value
+        #Run callbacks
+        self.run_callbacks()
+        #Acknowledge put completion
+        if use_complete and callback:
+            callback()
 
-@pytest.fixture(scope="module")
-def get_m1h():
-    return OffsetMirror("MIRR:FEE1:M1H", 'STEP:M1H')
+def using_fake_epics_pv(fcn):
+    @wraps(fcn)
+    def wrapped(*args, **kwargs):
+        pv_backup = epics.PV
+        epics.PV = FakeEpicsPV
+        try:
+            return fcn(*args, **kwargs)
+        finally:
+            epics.PV = pv_backup
 
-@pytest.fixture(scope="module")
-def get_p3h_pim():
-    return PIMFee("CAMR:FEE1:913", prefix_pos="FEE1:P3H", 
-                  ioc="IOC:FEE1:PROFILEMON")
-
-@pytest.fixture(scope="module")
-def get_p3h_det():
-    return FeeOpalDetector("CAMR:FEE1:913")
-
-@pytest.fixture(scope="module")
-def get_dg3_pim():
-    return PIM("HFX:DG3:PIM")
-
-@pytest.fixture(scope="module")
-def get_dg3_det():
-    return PIMPulnixDetector("HFX:DG3:CVV:01")
-
-@pytest.fixture(scope="module")
-def get_dg3_mot():
-    return PIMMotor("HFX:DG3:PIM")
+    return wrapped

--- a/tests/test_epics_ipm.py
+++ b/tests/test_epics_ipm.py
@@ -1,0 +1,59 @@
+############
+# Standard #
+############
+import logging
+import time
+###############
+# Third Party #
+###############
+import pytest
+from unittest.mock import Mock
+##########
+# Module #
+##########
+from .conftest import using_fake_epics_pv
+from pcdsdevices.epics import IPM
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def ipm():
+    return IPM("Test:My:IPM")
+
+
+@using_fake_epics_pv
+def test_ipm_states(ipm):
+    ipm.target.state._read_pv.put('OUT')
+    assert ipm.removed
+    assert not ipm.inserted
+    ipm.target.state._read_pv.put('TARGET1')
+    assert not ipm.removed
+    assert ipm.inserted
+
+
+@using_fake_epics_pv
+def test_ipm_motion(ipm):
+    #Remove IPM Targets
+    ipm.remove(wait=True, timeout=1.0)
+    assert ipm.target.state._write_pv.get() == 'OUT'
+    #Insert IPM Targets
+    ipm.target_in(1)
+    assert ipm.target.state._write_pv.get() == 'TARGET1'
+    #Move diodes in 
+    ipm.diode_in()
+    assert ipm.diode.state._write_pv.get() == 'IN'
+    ipm.diode_out()
+    #Move diodes out
+    assert ipm.diode.state._write_pv.get() == 'OUT'
+
+
+@using_fake_epics_pv
+def test_ipm_subscriptions(ipm):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    ipm.subscribe(cb, event_type=ipm.SUB_ST_CHG, run=False)
+    #Change the target state
+    ipm.target.state._read_pv.put('OUT')
+    assert cb.called
+

--- a/tests_live/conftest.py
+++ b/tests_live/conftest.py
@@ -1,7 +1,9 @@
 ############
 # Standard #
 ############
+import re
 import logging
+from collections import OrderedDict
 
 ###############
 # Third Party #
@@ -12,6 +14,12 @@ import pytest
 ##########
 # Module #
 ##########
+from pcdsdevices import (ImsMotor, GateValve, Slits, Attenuator,
+                         PulsePickerPink, Stopper, PPSStopper, IPM, PIM, 
+                         PIMMotor, PIMPulnixDetector, LODCM, OffsetMirror, 
+                         PIMFee )
+from pcdsdevices.epics.areadetector.detectors import (FeeOpalDetector,
+                                                       PulnixDetector)
 
 logger = logging.getLogger(__name__)
 
@@ -28,3 +36,97 @@ epics_subnet = val is not None
 requires_epics = pytest.mark.skipif(not epics_subnet,
                                     reason="Could not connect to sample PV")
 
+class Params:
+    registry = OrderedDict()
+
+    def __init__(self, name, cls, prefix, *args, **kwargs):
+        self.cls = cls
+        self.prefix = prefix
+        self.name = name
+        kwargs["name"] = name
+        self.args = args
+        self.kwargs = kwargs
+        self.registry[name] = self
+
+    def __del__(self):
+        del self.registry[self.name]
+
+    @classmethod
+    def get(cls, param="name", regex=None):
+        if regex is None:
+            params = list(cls.registry.values())
+        else:
+            params = []
+            for param_obj in cls.registry.values():
+                if param == "cls":
+                    string = param_obj.cls.__name__
+                else:
+                    try:
+                        attr = getattr(param_obj, param)
+                    except AttributeError:
+                        attr = param_obj.kwargs[param]
+                    string = str(attr)
+                if re.search(string, regex):
+                    params.append(param_obj)
+        return params
+
+Params("xcs_ims_usr32", ImsMotor, "XCS:USR:MMS:32", ioc="IOC:XCS:USR:DUMB:IMS")
+Params("xcs_lam_valve1", GateValve, "XCS:LAM:VGC:01", ioc="XCS:R51:IOC:39")
+Params("xcs_slits6", Slits, "XCS:SB2:DS:JAWS", ioc="IOC:XCS:SB2:SLITS:IMS")
+Params("pp_pink", PulsePickerPink, "XCS:SB2:MMS:09", states="XCS:SB2:PP:Y",
+       ioc="XCS:IOC:PULSEPICKER:IMS", states_ioc="IOC:XCS:DEVICE:STATES")
+Params("xcs_att", Attenuator, "XCS:ATT", n_filters=10, ioc="IOC:XCS:ATT")
+Params("dg2_stopper", Stopper, "HFX:DG2:STP:01")
+Params("s5_pps_stopper", PPSStopper, "PPS:FEH1:4:S4STPRSUM")
+Params("xcs_ipm", IPM, "XCS:SB2:IPM6", ioc="IOC:XCS:SB2:IPM06:IMS",
+       data="XCS:SB2:IMB:01:SUM")
+Params("xcs_pim", PIM, "XCS:SB2:PIM6")
+Params("xcs_lodcm", LODCM, "XCS:LODCM", ioc="IOC:XCS:LODCM")
+Params("fee_homs", OffsetMirror, "MIRR:FEE1:M1H", 'STEP:M1H')
+Params("det_p3h", FeeOpalDetector, "CAMR:FEE1:913")
+Params("det_dg3", PIMPulnixDetector, "HFX:DG3:CVV:01")
+Params("fee_yag", PIMFee, "CAMR:FEE1:913", prefix_pos="FEE1:P3H", 
+       ioc="IOC:FEE1:PROFILEMON")
+Params("dg3_motor", PIMMotor, "HFX:DG3:PIM")
+Params("dg3_pim", PIM, "HFX:DG3:PIM")
+
+# TODO: add xpp table when xpp comes online
+
+all_params = Params.get()
+all_labels = [p.name for p in all_params]
+
+
+@pytest.fixture(scope="module",
+                params=all_params,
+                ids=all_labels)
+def all_devices(request):
+    cls = request.param.cls
+    prefix = request.param.prefix
+    args = request.param.args
+    kwargs = request.param.kwargs
+    return cls(prefix, *args, **kwargs)
+
+@pytest.fixture(scope="module")
+def get_m1h():
+    return OffsetMirror("MIRR:FEE1:M1H", 'STEP:M1H')
+
+@pytest.fixture(scope="module")
+def get_p3h_pim():
+    return PIMFee("CAMR:FEE1:913", prefix_pos="FEE1:P3H", 
+                  ioc="IOC:FEE1:PROFILEMON")
+
+@pytest.fixture(scope="module")
+def get_p3h_det():
+    return FeeOpalDetector("CAMR:FEE1:913")
+
+@pytest.fixture(scope="module")
+def get_dg3_pim():
+    return PIM("HFX:DG3:PIM")
+
+@pytest.fixture(scope="module")
+def get_dg3_det():
+    return PIMPulnixDetector("HFX:DG3:CVV:01")
+
+@pytest.fixture(scope="module")
+def get_dg3_mot():
+    return PIMMotor("HFX:DG3:PIM")


### PR DESCRIPTION
- All PCDS Devices are now using the LightInterface metaclass. This comes with an explicit dependency on lightpath, which is now in the `requirements.txt`. The defaults for the device are setup in such a way that we should never fail to have all the methods of the interface. The only thing we are risking is some incidental `NotImplementedError` 😄 
- I converted what `ophyd` was using for using_fake_epics_pv and made it more general. I wrote a ton of notes on some pitfalls I stumbled into while putting it together
- Finished a few things I missed cleanup tests
- Tested everything on the IPM device, should be ready for production use
