### PR TITLE
ENH: Timeouts on PIM moves

### DIFF
--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -747,7 +747,8 @@ class OffsetMirror(Device, PositionerBase):
 
     def __init__(self, prefix, prefix_xy, *, name=None, read_attrs=None,
                  parent=None, configuration_attrs=None, settle_time=0,
-                 tolerance=0.01, timeout=None, **kwargs):
+                 tolerance=0.01, timeout=None, nominal_position=None,
+                 **kwargs):
 
         self._prefix_xy = prefix_xy
         self._area = prefix.split(":")[1]
@@ -766,10 +767,8 @@ class OffsetMirror(Device, PositionerBase):
                          **kwargs)
         self.settle_time = settle_time
         self.tolerance = tolerance
-        self.pitch.timeout = self.timeout
-        self.piezo.timeout = self.timeout
-        self.gan_x_p.timeout = self.timeout
-        self.gan_y_p.timeout = self.timeout
+        self.timeout = timeout
+        self.nominal_position = nominal_position
 
     def move(self, position, wait=True, **kwargs):
         """
@@ -999,3 +998,26 @@ class OffsetMirror(Device, PositionerBase):
         Sets the limits of the user_setpoint pv
         """
         self.pitch.limits = value
+
+    @property
+    def timeout(self):
+        return self.pitch.timeout
+
+    @timeout.setter
+    def timeout(self, tmo):
+        if tmo is not None:
+            tmo = float(tmo)
+        self.pitch.timeout = tmo
+        self.piezo.timeout = tmo
+        self.gan_x_p.timeout = tmo
+        self.gan_y_p.timeout = tmo
+
+    @property
+    def nominal_position(self):
+        return self.pitch.nominal_position
+
+    @nominal_position.setter
+    def nominal_position(self, pos):
+        if pos is not None:
+            pos = float(pos)
+        self.pitch.nominal_position = pos

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -733,16 +733,14 @@ class OffsetMirror(Device, PositionerBase):
         position
     """
     # Pitch Motor
-    pitch = FormattedComponent(OMMotor, "{self.prefix}",
-                               timeout="{self.timeout}")
+    pitch = FormattedComponent(OMMotor, "{self.prefix}")
+
     # Piezo Motor
-    piezo = FormattedComponent(Piezo, "PIEZO:{self._area}:{self._mirror}",
-                               timeout="{self.timeout}")
+    piezo = FormattedComponent(Piezo, "PIEZO:{self._area}:{self._mirror}")
+
     # Gantry motors
-    gan_x_p = FormattedComponent(OMMotor, "{self._prefix_xy}:X:P",
-                                 timeout="{self.timeout}")
-    gan_y_p = FormattedComponent(OMMotor, "{self._prefix_xy}:Y:P",
-                                 timeout="{self.timeout}")
+    gan_x_p = FormattedComponent(OMMotor, "{self._prefix_xy}:X:P")
+    gan_y_p = FormattedComponent(OMMotor, "{self._prefix_xy}:Y:P")
 
     # This is not implemented in the PLC. Included to appease bluesky
     motor_stop = Component(Signal, value=0)
@@ -768,6 +766,10 @@ class OffsetMirror(Device, PositionerBase):
                          **kwargs)
         self.settle_time = settle_time
         self.tolerance = tolerance
+        self.pitch.timeout = self.timeout
+        self.piezo.timeout = self.timeout
+        self.gan_x_p.timeout = self.timeout
+        self.gan_y_p.timeout = self.timeout
 
     def move(self, position, wait=True, **kwargs):
         """

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -747,7 +747,6 @@ class OffsetMirror(Device, PositionerBase):
     # This is not implemented in the PLC. Included to appease bluesky
     motor_stop = Component(Signal, value=0)
 
-    # Currently structured to pass the ioc argument down to the pitch motor
     def __init__(self, prefix, prefix_xy, *, name=None, read_attrs=None,
                  parent=None, configuration_attrs=None, settle_time=0,
                  tolerance=0.01, timeout=None, **kwargs):
@@ -823,7 +822,7 @@ class OffsetMirror(Device, PositionerBase):
         -------
         position : float
         """
-        return self.pitch.user_readback.value
+        return self.pitch.position
 
     @property
     @raise_if_disconnected

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -229,7 +229,7 @@ class PIMMotor(Device, PositionerBase):
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs, name=name,
                          parent=parent, timeout=timeout, **kwargs)
-        self.states.timeout = timeout
+        self.timeout = timeout
 
     def move_in(self, wait=True, **kwargs):
         """
@@ -375,6 +375,14 @@ class PIMMotor(Device, PositionerBase):
     def unstage(self):
         self.move_out(wait=False)
         return super().unstage()
+
+    @property
+    def timeout(self):
+        return self.states.timeout
+
+    @timeout.setter
+    def timeout(self, tmo):
+        self.states.timeout = float(tmo)
 
 
 class PIM(PIMMotor):

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -5,26 +5,26 @@ Profile Intensity Monitor Classes
 
 This script contains all the classes relating to the profile intensity monitor
 classes at the user level. A PIM will usually have at least a motor to control
-yag position and a camera to view the yag. Additional motors to adjust focus and
-zoom can also be included as in the case of the PIMs in the FEE.
+yag position and a camera to view the yag. Additional motors to adjust focus
+and zoom can also be included as in the case of the PIMs in the FEE.
 
 Classes Implemented here are as follows:
 
 PIMPulnixDetector
-	Pulnix detector with only the plugins used by the PIMs.
+    Pulnix detector with only the plugins used by the PIMs.
 
 PIMMotor
-	Profile intensity monitor motor that moves the yag and diode into and out of
-	the beam.
+    Profile intensity monitor motor that moves the yag and diode into and out
+    of the beam.
 
 PIM
-	High level profile intensity monitor class that inherits from PIMMotor and
-	has a PIMPulnixDetector as a component.
+    High level profile intensity monitor class that inherits from PIMMotor and
+    has a PIMPulnixDetector as a component.
 
 PIMFee
-	High level profile inensity monitor class that is used in the fee. It has
-	three IMS motors to control zoom, focus and the position of the yag in
-	addition to a FeeOpalDetector as the detector.
+    High level profile inensity monitor class that is used in the fee. It has
+    three IMS motors to control zoom, focus and the position of the yag in
+    addition to a FeeOpalDetector as the detector.
 """
 
 ############
@@ -44,13 +44,12 @@ from ophyd.utils.epics_pvs import raise_if_disconnected
 ##########
 from .device import Device
 from .imsmotor import ImsMotor
-from .iocdevice import IocDevice
 from .state import statesrecord_class
 from ophyd.status import wait as status_wait
 from .signal import (EpicsSignal, EpicsSignalRO)
 from .component import (Component, FormattedComponent)
 from .areadetector.detectors import (PulnixDetector, FeeOpalDetector)
-from .areadetector.plugins import (ImagePlugin, StatsPlugin, ProcessPlugin)
+from .areadetector.plugins import (ImagePlugin, StatsPlugin)
 from ..utils.pyutils import isnumber
 
 logger = logging.getLogger(__name__)
@@ -66,14 +65,15 @@ class PIMPulnixDetector(PulnixDetector):
     Components
     ----------
     image1 : ImagePlugin, ":IMAGE1:"
-    	Plugin component corresponding to image1 plugin in AD
+        Plugin component corresponding to image1 plugin in AD
 
     stats2 : StatsPlugin, ":Stats2:"
-    	Plugin component corresponding to stats2 plugin in AD    
+        Plugin component corresponding to stats2 plugin in AD
     """
     image1 = Component(ImagePlugin, ":IMAGE1:", read_attrs=['array_data'])
     stats2 = Component(StatsPlugin, ":Stats2:", read_attrs=['centroid',
                                                             'mean_value'])
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.image1.stage_sigs[self.image1.nd_array_port] = 'CAM'
@@ -95,7 +95,7 @@ class PIMPulnixDetector(PulnixDetector):
         Raises
         ------
         NotAcquiringError
-        	Error raised if called when the camera is not acquiring
+            Error raised if called when the camera is not acquiring
         """
         if not self.acquiring:
             raise NotAcquiringError
@@ -109,10 +109,10 @@ class PIMPulnixDetector(PulnixDetector):
         Returns
         -------
         image : np.ndarray
-        	Image array
+            Image array
         """
         return self.image1.image
-    
+
     @property
     @raise_if_disconnected
     def acquiring(self):
@@ -146,12 +146,12 @@ class PIMPulnixDetector(PulnixDetector):
         Returns
         -------
         centroid_x : float
-        	Centroid of the image in x.
+            Centroid of the image in x.
 
         Raises
         ------
         NotAcquiringError
-        	When this property is called but the camera isn't acquiring.
+            When this property is called but the camera isn't acquiring.
         """
         # Make sure the camera is acquiring
         self.check_camera()
@@ -166,12 +166,12 @@ class PIMPulnixDetector(PulnixDetector):
         Returns
         -------
         centroid_y : float
-        	Centroid of the image in y.
+            Centroid of the image in y.
 
         Raises
         ------
         NotAcquiringError
-        	When this property is called but the camera isn't acquiring.        
+            When this property is called but the camera isn't acquiring.
         """
         self.check_camera()
         return self.stats2.centroid.y.value
@@ -179,30 +179,32 @@ class PIMPulnixDetector(PulnixDetector):
     @property
     def centroid(self):
         """
-        Returns the beam centroid in x and y. Alias for (centroid_x, centroid_y)
+        Returns the beam centroid in x and y. Alias for
+        (centroid_x, centroid_y)
 
         Returns
         -------
         centroids : tuple
-        	Tuple of the centroids in x and y
+            Tuple of the centroids in x and y
 
         Raises
         ------
         NotAcquiringError
-        	When this property is called but the camera isn't acquiring.                
+            When this property is called but the camera isn't
+            acquiring.
         """
         return (self.centroid_x, self.centroid_y)
-        
+
 
 class PIMMotor(Device, PositionerBase):
     """
-    Standard position monitor motor that can move the stage to insert the yag or
-    diode, or retract it from the beam path.
+    Standard position monitor motor that can move the stage to insert the yag
+    or diode, or retract it from the beam path.
 
     Components
     ----------
     states : PIMStates
-    	States component that handles all the motor states.
+        States component that handles all the motor states.
 
     Parameters
     ----------
@@ -218,7 +220,7 @@ class PIMMotor(Device, PositionerBase):
         in read_configuration(), and describe_configuration() calls)
 
     name : str, optional
-        The name of the offset mirror    
+        The name of the offset mirror
     """
     states = FormattedComponent(PIMStates, "{self.prefix}",
                                 timeout="{self.timeout}")
@@ -238,14 +240,14 @@ class PIMMotor(Device, PositionerBase):
         Returns
         -------
         status : MoveStatus
-            Status object of the move        
+            Status object of the move
         """
         return self.move("YAG", wait=wait, **kwargs)
 
     def move_out(self, wait=True, **kwargs):
         """
         Move the PIM to the OUT position. Alias for move("OUTx").
-        
+
         Returns
         -------
         status : MoveStatus
@@ -270,17 +272,17 @@ class PIMMotor(Device, PositionerBase):
         to complete. String inputs are not case sensitive and must be one of
         the following:
 
-        	"DIODE", "OUT", "IN", "YAG"
+            "DIODE", "OUT", "IN", "YAG"
 
         Enumerated positions can also be inputted where:
 
-        	1 : "DIODE", 2 : "OUT", 3 : "IN", 3 : "YAG"
-        
+            1 : "DIODE", 2 : "OUT", 3 : "IN", 3 : "YAG"
+
         Parameters
         ----------
         position : str or number
             String or enumerated position to move to.
-        
+
         wait : bool, optional
             Wait for the status object to complete the move before returning
 
@@ -289,8 +291,8 @@ class PIMMotor(Device, PositionerBase):
             for this positioner is used
 
         settle_time: float, optional
-        	Delay after the set() has completed to indicate completion to the
-        	caller        
+            Delay after the set() has completed to indicate completion to the
+            caller
 
         Returns
         -------
@@ -300,7 +302,7 @@ class PIMMotor(Device, PositionerBase):
         Raises
         ------
         ValueError
-        	If the inputted position to move to is not a valid position
+            If the inputted position to move to is not a valid position
         """
         # If position is a number, check it is a valid enumeration state
         if isnumber(position) and position in (1, 2, 3):
@@ -308,7 +310,7 @@ class PIMMotor(Device, PositionerBase):
 
         # If string check it is a valid state for the motor
         elif isinstance(position, str) and position.upper() in ("DIODE", "OUT",
-                                                                "IN", "YAG"): 
+                                                                "IN", "YAG"):
             if position.upper() == "IN":
                 status = self.states.move("YAG", **kwargs)
             else:
@@ -324,7 +326,7 @@ class PIMMotor(Device, PositionerBase):
         return status
 
     mv = move
-        
+
     @property
     @raise_if_disconnected
     def position(self):
@@ -385,7 +387,7 @@ class PIM(PIMMotor):
     Components
     ----------
     detector : PIMPulnixDetector
-    	Pulnix detector used in the PIMs
+        Pulnix detector used in the PIMs
 
     Parameters
     ----------
@@ -393,8 +395,8 @@ class PIM(PIMMotor):
         The EPICS base of the motor
 
     prefix_det : str, optional
-        The EPICS base PV of the detector. If None, it will be inferred from the
-    	motor prefix
+        The EPICS base PV of the detector. If None, it will be inferred from
+        the motor prefix
 
     read_attrs : sequence of attribute names, optional
         The signals to be read during data acquisition (i.e., in read() and
@@ -420,7 +422,7 @@ class PIM(PIMMotor):
         else:
             self._prefix_det = prefix_det
         super().__init__(prefix, **kwargs)
-        
+
         # Override check_camera to include checking the yag has been inserted
         self.detector.check_camera = self.check_camera
 
@@ -431,16 +433,16 @@ class PIM(PIMMotor):
         Raises
         ------
         NotInsertedError
-        	Error raised if the camera is not in the inserted position
+            Error raised if the camera is not in the inserted position
         NotAcquiringError
-        	Error raised if the camera is not acquiring
+            Error raised if the camera is not acquiring
         """
         if not self.detector.acquiring:
             raise NotAcquiringError
         if not self.inserted:
             raise NotInsertedError
-    
-    
+
+
 class PIMFee(Device):
     """
     PIM class for the PIMs in the FEE that run using Dehong's custom ioc.
@@ -448,22 +450,22 @@ class PIMFee(Device):
     Components
     ----------
     detector : FeeOpalDetector
-    	Detector used in the PIM
+        Detector used in the PIM
 
     yag : ImsMotor
-    	Motor that controls the position of the yag
-    
+        Motor that controls the position of the yag
+
     zoom : ImsMotor
-    	Motor that controls the zoom
+        Motor that controls the zoom
 
     focus : ImsMotor
-    	Motor that controls the focus
+        Motor that controls the focus
 
     go : EpicsSignal
-    	Signal to move the yag in and out
+        Signal to move the yag in and out
 
     pos : EpicsSignalRO
-    	Readback for the position as a state
+        Readback for the position as a state
 
     Parameters
     ----------
@@ -485,27 +487,27 @@ class PIMFee(Device):
         The name of the offset mirror
     """
     # Opal
-    detector = FormattedComponent(FeeOpalDetector, "{self._prefix}", 
-                                name="Opal Camera")
+    detector = FormattedComponent(FeeOpalDetector, "{self._prefix}",
+                                  name="Opal Camera")
 
     # Yag Motors
-    yag = FormattedComponent(ImsMotor, "{self._prefix}:MOTR", 
+    yag = FormattedComponent(ImsMotor, "{self._prefix}:MOTR",
                              ioc="{self._ioc}", name="Yag Motor")
-    zoom = FormattedComponent(ImsMotor, "{self._prefix}:CLZ:01", 
+    zoom = FormattedComponent(ImsMotor, "{self._prefix}:CLZ:01",
                               ioc="{self._ioc}", name="Zoom Motor")
-    focus = FormattedComponent(ImsMotor, "{self._prefix}:CLF:01", 
+    focus = FormattedComponent(ImsMotor, "{self._prefix}:CLF:01",
                                ioc="{self._ioc}", name="Focus Motor")
-    
+
     # Position PV
     go = FormattedComponent(EpicsSignal, "{self._prefix_pos}:YAG:GO")
     pos = FormattedComponent(EpicsSignalRO, "{self._prefix_pos}:POSITION")
 
-    def __init__(self, prefix, *, prefix_pos="", ioc="", in_pos=0, out_pos=43, 
-                 read_attrs=None, name=None, parent=None, 
-                 configuration_attrs=None, **kwargs):        
+    def __init__(self, prefix, *, prefix_pos="", ioc="", in_pos=0, out_pos=43,
+                 read_attrs=None, name=None, parent=None,
+                 configuration_attrs=None, **kwargs):
         self._prefix = prefix
         self._prefix_pos = prefix_pos
-        self._ioc=ioc
+        self._ioc = ioc
         self.in_pos = in_pos
         self.out_pos = out_pos
 
@@ -513,9 +515,10 @@ class PIMFee(Device):
             read_attrs = ['detector', 'zoom', 'focus', 'yag', 'pos']
         if configuration_attrs is None:
             configuration_attrs = ['detector', 'zoom', 'focus', 'yag', 'pos']
-            
-        super().__init__(prefix, read_attrs=read_attrs, name=name, parent=parent,
-                         configuration_attrs=configuration_attrs, **kwargs)    
+
+        super().__init__(prefix, read_attrs=read_attrs, name=name,
+                         parent=parent,
+                         configuration_attrs=configuration_attrs, **kwargs)
 
     def check_camera(self):
         """
@@ -524,9 +527,9 @@ class PIMFee(Device):
         Raises
         ------
         NotInsertedError
-        	Error raised if the camera is not in the inserted position
+            Error raised if the camera is not in the inserted position
         NotAcquiringError
-        	Error raised if the camera is not acquiring
+            Error raised if the camera is not acquiring
         """
         if not self.detector.acquiring:
             raise NotAcquiringError
@@ -536,7 +539,7 @@ class PIMFee(Device):
     def move_in(self, wait=True, **kwargs):
         """
         Move the PIM to the IN position. Alias for move("IN").
-        
+
         Returns
         -------
         status : MoveStatus
@@ -558,19 +561,19 @@ class PIMFee(Device):
     def move(self, position, wait=True, **kwargs):
         """
         Move the yag motor to the inputted state, optionally waiting for the
-        move to complete. String inputs are not case sensitive and must be one of
-        the following:
+        move to complete. String inputs are not case sensitive and must be one
+        of the following:
 
-        	"IN", "OUT"
+            "IN", "OUT"
 
         If a number is passed then the yag motor will be moved the inputted
         position.
-        
+
         Parameters
         ----------
         position : str or number
             String or position to move to.
-        
+
         wait : bool, optional
             Wait for the status object to complete the move before returning
 
@@ -579,8 +582,8 @@ class PIMFee(Device):
             for this positioner is used
 
         settle_time: float, optional
-        	Delay after the set() has completed to indicate completion to the
-        	caller                
+            Delay after the set() has completed to indicate completion to the
+            caller
 
         Returns
         -------
@@ -590,7 +593,7 @@ class PIMFee(Device):
         Raises
         ------
         ValueError
-        	If the inputted position to move to is not a valid position        
+            If the inputted position to move to is not a valid position
         """
         # Handle string inputs
         if isinstance(position, str):
@@ -615,7 +618,7 @@ class PIMFee(Device):
 
     def mv(self, position, **kwargs):
         return self.move(position, **kwargs)
-        
+
     @property
     @raise_if_disconnected
     def position(self):
@@ -624,7 +627,7 @@ class PIMFee(Device):
 
         Returns
         -------
-        position : str        
+        position : str
         """
         return self.pos.value
 
@@ -636,7 +639,7 @@ class PIMFee(Device):
 
         Returns
         -------
-        position : str                
+        position : str
         """
         return self.position
 
@@ -650,12 +653,12 @@ class PIMFee(Device):
         Returns
         -------
         image : np.ndarray
-        	Image array
+            Image array
         """
         return np.reshape(np.array(self.cam.array_data.value),
                           (self.cam.size.size_y.value,
                            self.cam.size.size_x.value))
-                         
+
     @property
     @raise_if_disconnected
     def blocking(self):
@@ -665,7 +668,7 @@ class PIMFee(Device):
         Returns
         -------
         blocking : bool
-        """        
+        """
         return not bool(self.pos.value)
 
     @property
@@ -700,6 +703,7 @@ class NotAcquiringError(PIMExceptions):
     def __init__(self, *args, **kwargs):
         self.msg = kwargs.pop("msg", "Camera currently not acquiring images.")
         super().__init__(*args, **kwargs)
+
     def __str__(self):
         return repr(self.msg)
 
@@ -713,5 +717,6 @@ class NotInsertedError(PIMExceptions):
         self.msg = kwargs.pop(
             "msg", "Camera currently not in inserted position.")
         super().__init__(*args, **kwargs)
+
     def __str__(self):
         return repr(self.msg)

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -382,7 +382,9 @@ class PIMMotor(Device, PositionerBase):
 
     @timeout.setter
     def timeout(self, tmo):
-        self.states.timeout = float(tmo)
+        if tmo is not None:
+            tmo = float(tmo)
+        self.states.timeout = tmo
 
 
 class PIM(PIMMotor):

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -294,15 +294,15 @@ class PIMMotor(Device):
         """
         # If position is a number, check it is a valid enumeration state
         if isnumber(position) and position in (1, 2, 3):
-            status = self.states.state.set(position, **kwargs)
+            status = self.states.move(position, **kwargs)
 
         # If string check it is a valid state for the motor
         elif isinstance(position, str) and position.upper() in ("DIODE", "OUT",
                                                                 "IN", "YAG"): 
             if position.upper() == "IN":
-                status = self.states.state.set("YAG", **kwargs)
+                status = self.states.move("YAG", **kwargs)
             else:
-                status = self.states.state.set(position.upper(), **kwargs)
+                status = self.states.move(position.upper(), **kwargs)
         else:
             # Invalid position inputted
             raise ValueError("Position must be a PIM valid state.")

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -222,8 +222,7 @@ class PIMMotor(Device, PositionerBase):
     name : str, optional
         The name of the offset mirror
     """
-    states = FormattedComponent(PIMStates, "{self.prefix}",
-                                timeout="{self.timeout}")
+    states = FormattedComponent(PIMStates, "{self.prefix}")
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
                  name=None, parent=None, timeout=None, **kwargs):
@@ -232,6 +231,7 @@ class PIMMotor(Device, PositionerBase):
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs, name=name,
                          parent=parent, timeout=timeout, **kwargs)
+        self.states.timeout = timeout
 
     def move_in(self, wait=True, **kwargs):
         """

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -598,13 +598,13 @@ class PIMFee(Device):
         # Handle string inputs
         if isinstance(position, str):
             if position.upper() in ("IN", "OUT"):
-                status = go.set(position.upper(), **kwargs)
+                status = self.go.set(position.upper(), **kwargs)
             else:
                 raise ValueError("Position must be a PIM valid state.")
 
         # Handle position inputs
         elif isnumber(position):
-            status = yag.move(position, wait=wait, **kwargs)
+            status = self.yag.move(position, wait=wait, **kwargs)
 
         # Everything else
         else:

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -226,8 +226,6 @@ class PIMMotor(Device, PositionerBase):
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
                  name=None, parent=None, timeout=None, **kwargs):
-        if read_attrs is None:
-            read_attrs = ["states"]
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs, name=name,
                          parent=parent, timeout=timeout, **kwargs)
@@ -412,7 +410,7 @@ class PIM(PIMMotor):
     detector = FormattedComponent(PIMPulnixDetector, "{self._prefix_det}",
                                   read_attrs=['stats2'])
 
-    def __init__(self, prefix, prefix_det=None, **kwargs):
+    def __init__(self, prefix, prefix_det=None, read_attrs=None, **kwargs):
         # Infer the detector PV from the motor PV
         if not prefix_det:
             self._section = prefix.split(":")[0]
@@ -421,7 +419,7 @@ class PIM(PIMMotor):
                 self._section, self._imager)
         else:
             self._prefix_det = prefix_det
-        super().__init__(prefix, **kwargs)
+        super().__init__(prefix, read_attrs=read_attrs, **kwargs)
 
         # Override check_camera to include checking the yag has been inserted
         self.detector.check_camera = self.check_camera

--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -155,18 +155,18 @@ class DeviceStatesRecord(State, PositionerBase):
     """
     state = Component(EpicsSignal, "", write_pv=":GO", string=True,
                       auto_monitor=True, limits=False, put_complete=True)
-    SUB_RBK_CHG  = 'state_readback_changed'
-    SUB_SET_CHG  = 'state_setpoint_changed'
+    SUB_RBK_CHG = 'state_readback_changed'
+    SUB_SET_CHG = 'state_setpoint_changed'
     _default_sub = SUB_RBK_CHG
 
     def __init__(self, prefix, *, read_attrs=None, name=None, timeout=None,
                  **kwargs):
-        #Initialize device
+        # Initialize device
         if read_attrs is None:
             read_attrs = ["state"]
         super().__init__(prefix, read_attrs=read_attrs, name=name,
                          timeout=timeout, **kwargs)
-        #Add subscriptions
+        # Add subscriptions
         self.state.subscribe(self._setpoint_changed,
                              event_type=self.state.SUB_SETPOINT,
                              run=False)
@@ -202,15 +202,15 @@ class DeviceStatesRecord(State, PositionerBase):
         self.state.put(value)
 
     def _setpoint_changed(self, **kwargs):
-        #Avoid duplicate keywords
+        # Avoid duplicate keywords
         kwargs.pop('sub_type', None)
-        #Run subscriptions
+        # Run subscriptions
         self._run_subs(sub_type=self.SUB_SET_CHG, **kwargs)
 
     def _read_changed(self, **kwargs):
-        #Avoid duplicate keywords
+        # Avoid duplicate keywords
         kwargs.pop('sub_type', None)
-        #Run subscriptions
+        # Run subscriptions
         self._run_subs(sub_type=self.SUB_RBK_CHG, **kwargs)
 
         # Handle move status
@@ -229,7 +229,7 @@ class DeviceStatesPart(Device):
     """
     Device to manipulate a specific set position.
     """
-    at_state = Component(EpicsSignalRO, "", string=True) 
+    at_state = Component(EpicsSignalRO, "", string=True)
     setpos = Component(EpicsSignal, "_SET")
     delta = Component(EpicsSignal, "_DELTA")
 

--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -187,11 +187,12 @@ class DeviceStatesRecord(State, PositionerBase):
         return status
 
     def check_value(self, value):
-        enums = self.state.enum_strs()
+        enums = self.state.enum_strs
         if value in enums or value in range(len(enums)):
             return
         else:
-            raise StateError("Value %s invalid. Enums are %s", value, enums)
+            raise StateError("Value {} invalid. Enums are {}".format(value,
+                                                                     enums))
 
     @property
     def position(self):
@@ -222,7 +223,7 @@ class DeviceStatesRecord(State, PositionerBase):
             readback = self.value
             if readback != "Unknown":
                 self._move_requested = False
-                setpoint = self.state.get_setpoint()
+                setpoint = self.state.get_setpoint(as_string=True)
                 success = setpoint == readback
                 timestamp = kwargs.pop("timestamp", time.time())
                 self._done_moving(success=success, timestamp=timestamp,

--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -194,6 +194,10 @@ class DeviceStatesRecord(State, PositionerBase):
             raise StateError("Value %s invalid. Enums are %s", value, enums)
 
     @property
+    def position(self):
+        return self.value
+
+    @property
     def value(self):
         return self.state.get(use_monitor=True)
 

--- a/pcdsdevices/sim/mirror.py
+++ b/pcdsdevices/sim/mirror.py
@@ -111,10 +111,10 @@ class OMMotor(mirror.OMMotor):
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None, 
                  name=None, parent=None, velocity=0, noise=0, settle_time=0, 
                  noise_func=None, noise_type="uni", noise_args=(), 
-                 noise_kwargs={}, **kwargs):
+                 noise_kwargs={}, timeout=None, **kwargs):
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs, name=name, 
-                         parent=parent, **kwargs)
+                         parent=parent, timeout=timeout, **kwargs)
         self.velocity.put(velocity)
         self.noise = noise
         self.settle_time = settle_time
@@ -240,12 +240,13 @@ class OffsetMirror(mirror.OffsetMirror, SimDevice):
                  noise_y=0, noise_z=0, noise_alpha=0, settle_time_x=0, 
                  settle_time_y=0, settle_time_z=0, settle_time_alpha=0, 
                  noise_func=None, noise_type="uni", noise_args=(), 
-                 noise_kwargs={}, **kwargs):
+                 noise_kwargs={}, timeout=None, **kwargs):
         if len(prefix.split(":")) < 3:
             prefix = "MIRR:TST:{0}".format(prefix)
         super().__init__(prefix, prefix_xy, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         name=name, parent=parent, **kwargs)
+                         name=name, parent=parent, timeout=timeout,
+                         **kwargs)
         self.log_pref = "{0} (OffsetMirror) - ".format(self.name)
 
         # Simulation Attributes

--- a/pcdsdevices/sim/mirror.py
+++ b/pcdsdevices/sim/mirror.py
@@ -223,7 +223,7 @@ class OffsetMirror(mirror.OffsetMirror, SimDevice):
         Amount of time to wait after moving alpha-motor
     """    
     # Pitch Motor
-    pitch = FormattedComponent(OMMotor, "{self._prefix}")
+    pitch = FormattedComponent(OMMotor, "{self.prefix}")
     # Gantry Motors
     gan_x_p = FormattedComponent(OMMotor, "STEP:{self._mirror}:X:P")
     gan_y_p = FormattedComponent(OMMotor, "STEP:{self._mirror}:Y:P")

--- a/pcdsdevices/sim/pim.py
+++ b/pcdsdevices/sim/pim.py
@@ -182,7 +182,7 @@ class PIMMotor(pim.PIMMotor):
     def move(self, position, **kwargs):
         if isinstance(position, str):
             if position.upper() in ("DIODE", "OUT", "IN", "YAG"): 
-                self.states.put("MOVING")
+                self.states.put("Unknown")
                 if position.upper() == "IN":
                     pos = "YAG"
                 else:

--- a/tests/test_sim_mirror.py
+++ b/tests/test_sim_mirror.py
@@ -143,7 +143,9 @@ def test_OffsetMirror_raises_limit_error_on_oob_positions():
     with pytest.raises(ValueError):   
         om.move(11)
     assert(om.move(0))
-    
-    
-    
-    
+
+def test_OffsetMirror_timeout():
+    tmo = 1.0
+    om = OffsetMirror("TEST", "TEST_XY", timeout=tmo)
+    om.move(42)
+    assert(om.pitch.timeout == tmo)

--- a/tests/test_sim_pim.py
+++ b/tests/test_sim_pim.py
@@ -5,6 +5,7 @@
 ############
 import time
 from collections import OrderedDict
+import pytest
 
 ###############
 # Third Party #
@@ -183,3 +184,10 @@ def test_PIMMotor_stage():
     pim.unstage()
     time.sleep(0.2)
     assert(pim.position == "OUT")
+
+@pytest.mark.skipif(True, reason="No proper states sim class yet")
+def test_PIM_timeout():
+    tmo = 1.0
+    pim = PIM("TEST", timeout=tmo)
+    pim.move_in()
+    assert(pim.states.timeout == tmo)


### PR DESCRIPTION
Transition PIMMotor and OffsetMirror to be subclasses of PositionerBase, adjusting a bit so we have timeouts, move waits, etc. that work properly with states, etc.

Most notable changes are in states, which now can move with proper status objects that can be waited on correctly rather than just looking for puts. This was tested on a live PIM this morning.

There were also a lot of commits where I switched tabs to spaces, etc. as I went, making some of these hard to look through, but I maintain it was needed.

I also added a fix to let us set nominal_position from the top-level OffsetMirror object.