### PR TITLE
FIX: Hotfix from Today

### DIFF
--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -747,7 +747,7 @@ class OffsetMirror(Device, PositionerBase):
 
     def __init__(self, prefix, prefix_xy, *, name=None, read_attrs=None,
                  parent=None, configuration_attrs=None, settle_time=0,
-                 tolerance=0.01, timeout=None, nominal_position=None,
+                 tolerance=0.5, timeout=None, nominal_position=None,
                  **kwargs):
 
         self._prefix_xy = prefix_xy

--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -161,6 +161,7 @@ class DeviceStatesRecord(State, PositionerBase):
 
     def __init__(self, prefix, *, read_attrs=None, name=None, timeout=None,
                  **kwargs):
+        self._move_requested = False
         # Initialize device
         if read_attrs is None:
             read_attrs = ["state"]
@@ -179,7 +180,11 @@ class DeviceStatesRecord(State, PositionerBase):
         status = super().move(position, moved_cb=moved_cb, timeout=timeout,
                               **kwargs)
         self._move_requested = True
-        self.state.put(position, wait=False)
+
+        if self.position != position:
+            self.state.put(position, wait=False)
+        else:
+            status._finished(success=True)
 
         if wait:
             status_wait(status)


### PR DESCRIPTION
A few quick fixes that were noticed last-minute. My changes to state resulted in a situation where moves to the current position would erroneously time out because they never transitioned. These now end immediately with success. There was also an issue where the real devices being moved by other programs would lead to a situation where an unset move_requested would cause a problem, so I set this at init.

I also bumped up the default position tolerance in the mirrors because we were having issues when a move command for the mirrors would wait until timeout if the position was just outside the tolerance range but still very small.