### PR TITLE
ENH: PVState improvements and Stoppers

### DIFF
--- a/pcdsdevices/epics/stopper.py
+++ b/pcdsdevices/epics/stopper.py
@@ -6,7 +6,7 @@ Generic X-Ray Stoppers
 import logging
 from enum import Enum
 
-from .state import pvstate_class
+from .state import pvstate_class, StateStatus
 from .device import Device
 from .signal import EpicsSignal
 from .component import Component as C
@@ -15,32 +15,14 @@ from .component import Component as C
 logger = logging.getLogger(__name__)
 
 
-class Commands(Enum):
-    """
-    Command aliases for ``CMD``
-    """
-    close_stopper = 0
-    open_stopper = 1
-
-
 PPS = pvstate_class('PPS',
-                    {'summary': {'pvname': '',
+                    {'signal': {'pvname': '',
                                  0: 'out',
                                  1: 'unknown',
                                  2: 'unknown',
                                  3: 'unknown',
                                  4: 'in'}},
                     doc='MPS Summary of Stopper state')
-
-
-Limits = pvstate_class('Limits',
-                       {'open_limit': {'pvname': ':OPEN',
-                                       0: 'defer',
-                                       1: 'out'},
-                        'closed_limit': {'pvname': ':CLOSE',
-                                         0: 'defer',
-                                         1: 'in'}},
-                       doc='State description of Stopper limits')
 
 
 class PPSStopper(Device):
@@ -50,8 +32,17 @@ class PPSStopper(Device):
     Control of this device only available to PPS systems. This class merely
     interprets the summary of limit switches to let the controls system know
     the current position
+
+    Parameters
+    ----------
+    prefix : str
+        Full PPS Stopper PV
+
+    name : str, optional
+        Alias for the stopper
     """
     summary = C(PPS, '')
+    _default_sub = PPS._default_sub
 
     def __init__(self, prefix, *, name=None,
                  read_attrs=None,
@@ -65,6 +56,76 @@ class PPSStopper(Device):
                          name=name, **kwargs)
 
 
+    @property
+    def inserted(self):
+        """
+        Inserted limit of PPS stopper
+        """
+        return self.summary.value == 'in'
+
+
+    @property
+    def removed(self):
+        """
+        Removed limit of the PPS Stopper
+        """
+        return self.summary.value == 'out'
+
+
+    def remove(self, **kwargs):
+        """
+        Stopper can not be controlled via EPICS
+
+        Raises
+        ------
+        PermissionError
+
+        Notes
+        -----
+        Exists to satisfy `lightpath` API
+        """
+        raise PermissionError("PPS Stopper {} can not be commanded via EPICS"
+                              "".format(self.name))
+
+
+    def subscribe(self, cb, event_type=None, run=False):
+        """
+        Subscribe to Stopper state changes
+
+        This simply maps to the :attr:`.summary` component
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        return self.summary.subscribe(cb, event_type=event_type, run=run)
+
+
+class Commands(Enum):
+    """
+    Command aliases for Stopper ``CMD`` record
+    """
+    close_stopper = 0
+    open_stopper  = 1
+
+
+Limits = pvstate_class('Limits',
+                       {'open_limit': {'pvname': ':OPEN',
+                                       0: 'defer',
+                                       1: 'out'},
+                        'closed_limit': {'pvname': ':CLOSE',
+                                         0: 'defer',
+                                         1: 'in'}},
+                       doc='State description of Stopper limits')
+
+
 class Stopper(Device):
     """
     Controls Stopper
@@ -72,11 +133,25 @@ class Stopper(Device):
     Similar to the :class:`.GateValve`, the Stopper class provides basic
     support for Controls stoppers i.e stoppers that can be commanded from
     outside the PPS system
+
+    Parameters
+    ----------
+    prefix : str
+        Full PPS Stopper PV
+
+    name : str, optional
+        Alias for the stopper
     """
-    command = C(EpicsSignal, ':CMD')
+    #Limit based states
     limits = C(Limits, '')
 
+    #Information on device control
+    command = C(EpicsSignal, ':CMD')
     commands = Commands
+
+    #Subscription information
+    SUB_LIMIT_CH = 'sub_limit_changed'
+    _default_sub = SUB_LIMIT_CH
 
     def __init__(self, prefix, *, name=None,
                  read_attrs=None,
@@ -88,15 +163,114 @@ class Stopper(Device):
         super().__init__(prefix,
                          read_attrs=read_attrs,
                          name=name, **kwargs)
+        #Subscribe callback to limits
+        self.limits.subscribe(self._limits_changed,
+                              run=False)
 
-    def open(self):
-        """
-        Remove the stopper from the beam
-        """
-        self.command.put(self.commands.open_stopper)
 
-    def close(self):
+    def open(self, wait=False, timeout=None):
+        """
+        Open the stopper
+        
+        Parameters
+        ----------
+        wait : bool, optional
+            Wait for the command to finish
+
+        timeout : float, optional
+            Default timeout to wait mark the request as a failure
+
+        Returns
+        -------
+        StateStatus:
+            Future that reports the completion of the request
+        """
+        #Command the stopper
+        self.command.put(self.commands.open_stopper.value)
+        #Create StateStatus
+        status = StateStatus(self.limits, 'out', timeout=timeout)
+        #Optional wait
+        if wait:
+            status_wait(status)
+
+        return status
+
+
+    def close(self, wait=False, timeout=None):
         """
         Close the stopper
+        
+        Parameters
+        ----------
+        wait : bool, optional
+            Wait for the command to finish
+
+        timeout : float, optional
+            Default timeout to wait mark the request as a failure
+
+        Returns
+        -------
+        StateStatus:
+            Future that reports the completion of the request
         """
-        self.command.put(self.commands.close_stopper)
+        #Command the stopper
+        self.command.put(self.commands.close_stopper.value)
+        #Create StateStatus
+        status = StateStatus(self.limits, 'in', timeout=timeout)
+        #Optional wait
+        if wait:
+            status_wait(status)
+
+        return status
+
+
+    def remove(self, wait=False, timeout=None):
+        """
+        Remove the stopper from the beam
+        
+        Parameters
+        ----------
+        wait : bool, optional
+            Wait for the command to finish
+
+        timeout : float, optional
+            Default timeout to wait mark the request as a failure
+
+        Returns
+        -------
+        StateStatus:
+            Future that reports the completion of the request
+    
+        Notes
+        -----
+        Satisfies lightpath API
+
+        See Also
+        --------
+        :meth:`.Stopper.remove`
+        """
+        return self.open(wait=wait, timeout=timeout)
+
+
+    @property
+    def inserted(self):
+        """
+        Whether the stopper is in the beamline
+        """
+        return self.limits.value == 'in'
+
+
+    @property
+    def removed(self):
+        """
+        Whether the stopper is removed from the beamline
+        """
+        return self.limits.value == 'out'
+
+
+    def _limits_changed(self, *args, **kwargs):
+        """
+        Callback when the limit state of the stopper changes
+        """
+        kwargs.pop('sub_type', None)
+        self._run_subs(sub_type=self.SUB_LIMIT_CH, **kwargs)

--- a/tests/test_epics_stopper.py
+++ b/tests/test_epics_stopper.py
@@ -1,0 +1,107 @@
+############
+# Standard #
+############
+import logging
+import time as ttime
+###############
+# Third Party #
+###############
+import pytest
+from unittest.mock import Mock
+
+##########
+# Module #
+##########
+from .conftest import using_fake_epics_pv
+from pcdsdevices.epics import PPSStopper, Stopper
+
+logger = logging.getLogger(__name__)
+
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def pps():
+    return PPSStopper("PPS:H0:SUM")
+
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def stopper():
+    return Stopper("STP:TST:")
+
+
+@using_fake_epics_pv
+def test_pps_states(pps):
+    #Removed
+    pps.summary.signal._read_pv.put(0)
+    assert pps.removed
+    assert not pps.inserted
+    #Inserted
+    pps.summary.signal._read_pv.put(4)
+    assert pps.inserted
+    assert not pps.removed
+
+    #Can not remove the PPS Stopper
+    with pytest.raises(PermissionError):
+        pps.remove()
+
+@using_fake_epics_pv
+def test_pps_subscriptions(pps):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    pps.subscribe(cb, run=False)
+    #Change readback state
+    pps.summary.signal._read_pv.put(4)
+    assert cb.called
+
+
+@using_fake_epics_pv
+def test_stopper_states(stopper):
+    #Removed
+    stopper.limits.open_limit._read_pv.put(1)
+    stopper.limits.closed_limit._read_pv.put(0)
+    assert stopper.removed
+    assert not stopper.inserted
+    #Inserted
+    stopper.limits.open_limit._read_pv.put(0)
+    stopper.limits.closed_limit._read_pv.put(1)
+    #Moving
+    stopper.limits.open_limit._read_pv.put(0)
+    stopper.limits.closed_limit._read_pv.put(0)
+    assert not stopper.inserted
+    assert not stopper.removed
+
+
+@using_fake_epics_pv
+def test_stopper_motion(stopper):
+    #Remove
+    status = stopper.remove(wait=False)
+    #Check write PV
+    assert stopper.command.value == stopper.commands.open_stopper.value
+    #Force state to check status object
+    stopper.limits.open_limit._read_pv.put(1)
+    stopper.limits.closed_limit._read_pv.put(0)
+    #Let state thread catch-up
+    ttime.sleep(0.1)
+    assert status.done and status.success
+    #Close
+    status = stopper.close(wait=False)
+    #Check write PV
+    assert stopper.command.value == stopper.commands.close_stopper.value
+    #Force state to check status object
+    stopper.limits.open_limit._read_pv.put(0)
+    stopper.limits.closed_limit._read_pv.put(1)
+    #Let state thread catch-up
+    ttime.sleep(0.1)
+    assert status.done and status.success
+
+
+@using_fake_epics_pv
+def test_stopper_subscriptions(stopper):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    stopper.subscribe(cb, run=False)
+    #Change readback state
+    stopper.limits.open_limit._read_pv.put(0)
+    stopper.limits.closed_limit._read_pv.put(1)
+    assert cb.called

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,42 +1,52 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import pytest
-
+import time as ttime
 from ophyd.signal import Signal
 
 from pcdsdevices.epics import state
-
+from pcdsdevices.epics.state import StateStatus
 
 
 class PrefixSignal(Signal):
     def __init__(self, prefix, **kwargs):
         super().__init__(**kwargs)
 
+@pytest.fixture(scope='function')
+def lim_info():
+    return dict(lowlim={"pvname": "LOW",
+                         0: "in",
+                         1: "defer"},
+                highlim={"pvname": "HIGH",
+                         0: "out",
+                         1: "defer"})
 
-def test_pvstate_class():
+def test_pvstate_class(lim_info):
     """
     Make sure all the internal logic works as expected. Use fake signals
     instead of EPICS signals with live hosts.
     """
-    # Define the info and the class
-    lim_info = dict(lowlim={"pvname": "LOW",
-                            0: "in",
-                            1: "defer"},
-                    highlim={"pvname": "HIGH",
-                             0: "out",
-                             1: "defer"})
+    # Define the class
     LimCls = state.pvstate_class("LimCls", lim_info, signal_class=PrefixSignal)
     lim_obj = LimCls("BASE")
 
     # Check the state machine
+    #Limits are defered
     lim_obj.lowlim.put(1)
     lim_obj.highlim.put(1)
     assert(lim_obj.value == "unknown")
+    #Limits are out
     lim_obj.highlim.put(0)
     assert(lim_obj.value == "out")
+    #Limits are in
     lim_obj.lowlim.put(0)
     lim_obj.highlim.put(1)
     assert(lim_obj.value == "in")
+    #Limits are in conflicting state
+    lim_obj.lowlim.put(0)
+    lim_obj.highlim.put(0)
+    assert(lim_obj.value == "unknown")
+
     assert("lowlim" in lim_obj.states)
     assert("highlim" in lim_obj.states)
 
@@ -61,6 +71,26 @@ def test_pvstate_class():
     assert(lim_obj2.value == "out")
     lim_obj2.value = "in"
     assert(lim_obj2.value == "in")
+
+
+def test_state_status(lim_info):
+    # Define the class
+    LimCls = state.pvstate_class("LimCls", lim_info, signal_class=PrefixSignal)
+    lim_obj = LimCls("BASE")
+    #Create a status for 'in'
+    status = StateStatus(lim_obj, 'in')
+    #Put readback to 'in'
+    lim_obj.lowlim.put(0)
+    lim_obj.highlim.put(1)
+    #Wait for threads to catch up
+    ttime.sleep(0.2)
+    assert status.done and status.success
+
+    #Create a status for 'out'
+    status = StateStatus(lim_obj, 'out', timeout=0.01)
+    #Let the timeout occur
+    ttime.sleep(1.0) #Set extra long to avoid race condition in tests
+    assert status.done and not status.success
 
 
 def test_statesrecord_class():

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -82,15 +82,17 @@ def test_state_status(lim_info):
     #Put readback to 'in'
     lim_obj.lowlim.put(0)
     lim_obj.highlim.put(1)
-    #Wait for threads to catch up
-    ttime.sleep(0.2)
     assert status.done and status.success
+    #Check our callback was cleared
+    assert status.check_state not in lim_obj._subs[lim_obj.SUB_STATE]
 
     #Create a status for 'out'
     status = StateStatus(lim_obj, 'out', timeout=0.01)
     #Let the timeout occur
     ttime.sleep(1.0) #Set extra long to avoid race condition in tests
     assert status.done and not status.success
+    #Check our callback was cleared
+    assert status.check_state not in lim_obj._subs[lim_obj.SUB_STATE]
 
 
 def test_statesrecord_class():


### PR DESCRIPTION
Changes
--------
* I changed the way the PVState looks at the signals to interpret the complete state. The way it was it just returned the first valid state it found. This way if multiple signals have conflicting states we will report "unknown" i.e a motor is unplugged both the `out` and `in` limit switches are tripped

* I added a generic `StateStatus` you can just give it one of the state devices and it will create a background thread that marks the status done when you reach the desired state. I felt a little like I was rewriting stuff but I couldn't really see an explicit implementation of what we wanted 

* `PPSStopper` and regular `Stopper`

Mostly requesting an explicit review because I want to make sure there is not a simpler way to do this with the device subscribes. Also @ZLLentz I wanted your opinion on whether I should switch the DeviceState to use the `StateStatus`.  It looks like it is all setup with Positioner but it is not obvious to me what is happening with the `timeout` on the `move` command? I'll let you advise.