### PR TITLE
ENH: Adding base classes for lower level devices to be used in SnD

### DIFF
--- a/pcdsdevices/epics/aerotech.py
+++ b/pcdsdevices/epics/aerotech.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Attocube devices
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+
+##########
+# Module #
+##########
+from .epicsmotor import Epicsmotor
+
+logger = logging.getLogger(__name__)
+
+
+class AeroBase(EpicsMotor):
+    """
+    Base Aerotech motor class.
+    """
+    pass
+
+
+class RotationAero(AeroBase):
+    """
+    Class for the aerotech rotation stage.
+    """
+    pass
+
+
+class LinearAero(AeroBase):
+    """
+    Class for the aerotech linear stage.
+    """
+    pass

--- a/pcdsdevices/epics/aerotech.py
+++ b/pcdsdevices/epics/aerotech.py
@@ -15,7 +15,7 @@ import logging
 ##########
 # Module #
 ##########
-from .epicsmotor import Epicsmotor
+from .epicsmotor import EpicsMotor
 
 logger = logging.getLogger(__name__)
 

--- a/pcdsdevices/epics/areadetector/cam.py
+++ b/pcdsdevices/epics/areadetector/cam.py
@@ -43,6 +43,7 @@ __all__ = ['CamBase',
            'RoperDetectorCam',
            'SimDetectorCam',
            'URLDetectorCam',
+           'GigeCam',
 ]
 
 
@@ -73,6 +74,10 @@ class AreaDetectorCam(cam.AreaDetectorCam, CamBase):
 
 
 class PulnixCam(CamBase):
+    pass
+
+
+class GigeCam(CamBase):
     pass
 
 

--- a/pcdsdevices/epics/areadetector/detectors.py
+++ b/pcdsdevices/epics/areadetector/detectors.py
@@ -38,7 +38,8 @@ __all__ = ['DetectorBase',
            'PvcamDetector',
            'RoperDetector',
            'SimDetector',
-           'URLDetector',
+           'URLDetector'
+           'GigeDetector',
 ]
 
 
@@ -63,6 +64,12 @@ class FeeOpalDetector(DetectorBase):
     """
     cam = ADComponent(cam.FeeOpalCam, ":")
 
+class GigeDetector(DetectorBase):
+    """
+    Gige Cam detector class.
+    """
+    cam = ADComponent(cam.GigeCam, ":")
+    
 
 class SimDetector(detectors.SimDetector, DetectorBase):
     pass

--- a/pcdsdevices/epics/attocube.py
+++ b/pcdsdevices/epics/attocube.py
@@ -18,7 +18,7 @@ import numpy as np
 ##########
 from .device import Device
 from .component import Component
-from .epicsmotor import Epicsmotor
+from .epicsmotor import EpicsMotor
 from .signal import (EpicsSignal, EpicsSignalRO)
 
 logger = logging.getLogger(__name__)
@@ -38,8 +38,8 @@ class EccController(Device):
         """
         Returns the firmware in the same date format as the EDM screen.
         """
-        return "{0}/{1}/{2}".format(self._firm_day.value, self._firm_month.value
-                                    self._firm_year.value)
+        return "{0}/{1}/{2}".format(
+            self._firm_day.value, self._firm_month.value, self._firm_year.value)
     
     @property
     def flash(self):

--- a/pcdsdevices/epics/attocube.py
+++ b/pcdsdevices/epics/attocube.py
@@ -21,12 +21,7 @@ from .component import Component
 from .epicsmotor import Epicsmotor
 from .signal import (EpicsSignal, EpicsSignalRO)
 
-
-class EccMotor(EpicsMotor):
-    """
-    ECC Motor Class
-    """
-    pass
+logger = logging.getLogger(__name__)
 
 
 class EccController(Device):
@@ -52,3 +47,36 @@ class EccController(Device):
         Saves the current configuration of the controller.
         """
         return self._flash.set(1)
+
+
+class EccMotor(EpicsMotor):
+    """
+    ECC Motor Class
+    """
+    pass
+
+
+class TranslationEcc(EccMotor):
+    """
+    Class for the translation ecc motor
+    """
+    pass
+
+
+class GoniometerEcc(EccMotor):
+    """
+    Class for the goniometer ecc motor
+    """
+    pass
+
+
+class DiodeEcc(EccMotor):
+    """
+    Class for the diode insertion ecc motor
+    """
+    pass
+
+
+
+
+

--- a/pcdsdevices/epics/diode.py
+++ b/pcdsdevices/epics/diode.py
@@ -16,7 +16,7 @@ import logging
 # Module #
 ##########
 from .micronix import VT50
-from .device import device
+from .device import Device
 from .component import Component
 from .areadetector.detectors import GigeDetector
 

--- a/pcdsdevices/epics/diode.py
+++ b/pcdsdevices/epics/diode.py
@@ -15,7 +15,10 @@ import logging
 ##########
 # Module #
 ##########
+from .micronix import VT50
 from .device import device
+from .component import Component
+from .areadetector.detectors import GigeDetector
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +35,20 @@ class HamamatsuDiode(DiodeBase):
     Class for the Hamamatsu diode.
     """
     pass
+
+
+class HamamatsuXMotionDiode(Device):
+    """
+    Class for the Hamamatsu diode but with an X motor
+    """
+    diode = Component(HamamatsuDiode, ":DIODE")
+    x = Component(VT50, ":X")
+
+
+class HamamatsuXYMotionCamDiode(HamamatsuXMotionDiode):
+    """
+    Class for the Hamamatsu diode but with X and Y motors
+    """
+    y = Component(VT50, ":Y")
+    cam = Component(GigeDetector, ":CAM")
+    

--- a/pcdsdevices/epics/diode.py
+++ b/pcdsdevices/epics/diode.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Diodes
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+
+##########
+# Module #
+##########
+from .device import device
+
+logger = logging.getLogger(__name__)
+
+
+class DiodeBase(Device):
+    """
+    Base class for the diode.
+    """
+    pass
+
+
+class HamamatsuDiode(DiodeBase):
+    """
+    Class for the Hamamatsu diode.
+    """
+    pass

--- a/pcdsdevices/epics/micronix.py
+++ b/pcdsdevices/epics/micronix.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Attocube devices
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+
+##########
+# Module #
+##########
+from .epicsmotor import EpicsMotor
+
+logger = logging.getLogger(__name__)
+
+
+class MicronixBase(EpicsMotor):
+    """
+    Base Micronix motor class.
+    """
+
+    
+class VT50(MicronixBase):
+    """
+    VT50 Micronix Motor
+    """
+    pass

--- a/pcdsdevices/epics/rtd.py
+++ b/pcdsdevices/epics/rtd.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+RTDs
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+
+##########
+# Module #
+##########
+from .device import device
+
+logger = logging.getLogger(__name__)
+
+
+class RTDBase(Device):
+    """
+    Base class for the RTD.
+    """
+    pass
+
+
+class OmegaRTD(RTDBase):
+    """
+    Class for the Omega RTD.
+    """
+    pass

--- a/pcdsdevices/epics/rtd.py
+++ b/pcdsdevices/epics/rtd.py
@@ -15,7 +15,7 @@ import logging
 ##########
 # Module #
 ##########
-from .device import device
+from .device import Device
 
 logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ class FakeEpicsPV(object):
         self._connection_callback = connection_callback
         self._form = form
         self._auto_monitor = auto_monitor
-        self._value = None
+        self._value = 0
         self._connected = True
         self._running = True
         self.enum_strs = enum_strs
@@ -261,3 +261,15 @@ def using_fake_epics_pv(fcn):
             epics.PV = pv_backup
 
     return wrapped
+
+def get_subclasses_in_module(module, cls):
+    subclasses = []
+    for dir_str in dir(module):
+        dir_cls = getattr(module, dir_str)
+        try:
+            if issubclass(dir_cls, cls):
+                subclasses.append(dir_cls)
+        except TypeError:
+            pass
+    return subclasses
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import random
 import logging
 import threading
 from functools import wraps
+import inspect
 
 import epics
 import numpy as np
@@ -262,14 +263,19 @@ def using_fake_epics_pv(fcn):
 
     return wrapped
 
-def get_subclasses_in_module(module, cls):
-    subclasses = []
-    for dir_str in dir(module):
-        dir_cls = getattr(module, dir_str)
+def get_classes_in_module(module, subcls=None):
+    classes = []
+    all_classes = inspect.getmembers(module)
+    for _, cls in all_classes:
         try:
-            if issubclass(dir_cls, cls):
-                subclasses.append(dir_cls)
-        except TypeError:
-            pass
-    return subclasses
-    
+            if cls.__module__ == module.__name__:
+                if subcls is not None:
+                    try:
+                        if not issubclass(cls, subcls):
+                            continue
+                    except TypeError:
+                        continue
+                classes.append(cls)
+        except AttributeError:
+            pass    
+    return classes

--- a/tests/test_epics_aerotech.py
+++ b/tests/test_epics_aerotech.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+import time
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+
+##########
+# Module #
+##########
+from .conftest import (using_fake_epics_pv, get_classes_in_module)
+from pcdsdevices.epics import aerotech
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(aerotech, Device))
+def test_aerotech_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))
+    

--- a/tests/test_epics_attocube.py
+++ b/tests/test_epics_attocube.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+import time
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+
+##########
+# Module #
+##########
+from .conftest import (using_fake_epics_pv, get_classes_in_module)
+from pcdsdevices.epics import attocube
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(attocube, Device))
+def test_attocube_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))
+    

--- a/tests/test_epics_diode.py
+++ b/tests/test_epics_diode.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+import time
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+
+##########
+# Module #
+##########
+from .conftest import (using_fake_epics_pv, get_classes_in_module)
+from pcdsdevices.epics import diode
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(diode, Device))
+def test_diode_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))

--- a/tests/test_epics_micronix.py
+++ b/tests/test_epics_micronix.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+import time
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+
+##########
+# Module #
+##########
+from .conftest import (using_fake_epics_pv, get_classes_in_module)
+from pcdsdevices.epics import micronix
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(micronix, Device))
+def test_micronix_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))

--- a/tests/test_epics_rtd.py
+++ b/tests/test_epics_rtd.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+import time
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+
+##########
+# Module #
+##########
+from .conftest import (using_fake_epics_pv, get_classes_in_module)
+from pcdsdevices.epics import rtd
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(rtd, Device))
+def test_rtd_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))


### PR DESCRIPTION
This PR adds the base classes for the lower level devices to be used in the split and delay system. They are mostly motors and are currently mostly empty but should, in theory, provide basic functionality for their respective motors assuming they all use the motor class correctly.

The classes are currently unfinished but this seemed like a good place to make the initial PR before continuing to work on them since tests pass both here and in SnD. Below are the classes:

**Motors**

`aerotech.py`
- `AeroBase` - Base class for all the aerotech motors
- `RotationAero` - Rotation aerotech motor stage.
- `LinearAero` - Linear aerotech motor. stage.

`attocube.py`
- `EccMotor` - Base class for the attocube ECC motors
- `TranslationEcc` - Linear translation attocube motor.
- `GoniometerEcc` - ECC motor that moves the goniometer.
- `DiodeEcc` - ECC motor that inserts and removes the diodes.
- `EccController` - Class for the attocube motor controller.

`micronix.py`
- `MicronixBase` - Base class for all the micronix motors (Currenly subclasses EpicsMotor. Needs to be inplemented with real micronix IOC.).
- `VT50` - Class for the micronix VT-50 motor.

**Detectors**

`diode.py`
_Note: Deprecate or add to these classes when we implement the wave8_
- `DiodeBase` - Base class for all diodes
- `HamamatsuDiode` - Class for the Hamamatsu diode used in SnD
- `HamamatsuXMotionDiode` - Hamamatsu diode with a micronix motor for the X motion.
- `HamamatsuXYMotionCamDiode` - Hamamatsu diode with micronix motors for X and Y motion along with a GigE camera.

`cam.py`
- `GigeCam` - Cam class for the gigecam

`detectors.py`
- `GigeDetector` - Detector class for the gige camera

In addition to these classes, some changes were made to `conftest.py`. A new function, `get_classes_in_module` is added that returns the classes defined in an inputted module. This made it cleaner to do basic ophyd tests when paired with pytest's `parametrize`.

I also changed the default value for the `self._value` attribute of `FakeEpicsPV` to be `0` because `None` was causing the tests mentioned above to fail.