### PR TITLE
ENH: Make subscriptions on PIMMotor pass down to states. Needed for gui.

### DIFF
--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -387,6 +387,12 @@ class PIMMotor(Device, PositionerBase):
             tmo = float(tmo)
         self.states.timeout = tmo
 
+    def subscribe(self, *args, **kwargs):
+        self.states.subscribe(*args, **kwargs)
+
+    def clear_sub(self, *args, **kwargs):
+        self.states.clear_sub(*args, **kwargs)
+
 
 class PIM(PIMMotor):
     """


### PR DESCRIPTION
The subscriptions on PIMMotor weren't really doing anything meaningful. What I really wanted was to be able to subscribe to state changes. The quickest way to implement this was to simply pass the subscribe/clear_sub method calls down to the component states object.