### PR TITLE
WIP: Optional choice to manually select ophyd class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,11 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pip wheel ophyd==0.6.1 pytest -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pip wheel happi ophyd==0.6.1 pytest -c conda-forge -c lightsource2-tag -c skywalker-dev
   #Launch Conda environment
   - source activate test-environment
-  #Install pedl
+  #Install mongomock
+  - pip install mongomock
   - pip install codecov
   - pip install -r requirements.txt
   #Install

--- a/pcdsdevices/happireader.py
+++ b/pcdsdevices/happireader.py
@@ -39,7 +39,7 @@ def read_happi(client=None):
     return client.all_devices
 
 
-def construct_device(happi_object, device_class=None):
+def construct_device(happi_object, device_class=None, **kwargs):
     """
     Create a functional device from the information stored in a happi device.
 
@@ -51,6 +51,8 @@ def construct_device(happi_object, device_class=None):
         Class to instantiate with given happi information. If no class is given
         one will be selected using the :func:`.pick_class` function
 
+    kwargs : 
+        Additional keywords are passed into the device constructor
     Returns
     -------
     device : ophyd.Device
@@ -68,7 +70,7 @@ def construct_device(happi_object, device_class=None):
         device_type = happi_object.__class__.__name__
         device_class = pick_class(device_type, info)
     #Instantiate device with information
-    return device_class(db_info=info, **info)
+    return device_class(db_info=info, **info, **kwargs)
 
 
 def pick_class(base, info):

--- a/pcdsdevices/happireader.py
+++ b/pcdsdevices/happireader.py
@@ -39,7 +39,7 @@ def read_happi(client=None):
     return client.all_devices
 
 
-def construct_device(happi_object):
+def construct_device(happi_object, device_class=None):
     """
     Create a functional device from the information stored in a happi device.
 
@@ -47,20 +47,28 @@ def construct_device(happi_object):
     ----------
     happi_object : happi.Device
 
+    device_class : class, optional
+        Class to instantiate with given happi information. If no class is given
+        one will be selected using the :func:`.pick_class` function
+
     Returns
     -------
     device : ophyd.Device
     """
     info = {}
+    #Gather information from device
     for entry in happi_object.info_names:
         try:
             info[entry] = getattr(happi_object, entry)
         except AttributeError:
             pass
     logger.debug("Extracted info dictionary from happi: %s", info)
-    device_type = happi_object.__class__.__name__
-    cls = pick_class(device_type, info)
-    return cls(db_info=info, **info)
+    #Class selection
+    if not device_class:
+        device_type = happi_object.__class__.__name__
+        device_class = pick_class(device_type, info)
+    #Instantiate device with information
+    return device_class(db_info=info, **info)
 
 
 def pick_class(base, info):


### PR DESCRIPTION
Minor tweak to force a device_class. This will allow us to deal with minor name differences like `Mirror` happi container vs. `OffsetMirror` pcdsdevices

**WIP:** Should also check the device to see if it specifies a specific class