### PR TITLE
No wait in stage

### DIFF
--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -422,16 +422,6 @@ class OMMotor(Device, PositionerBase):
         """
         return (self.low_limit, self.high_limit)
 
-    def stage(self):
-        """
-        Stage the OMS motor to nominal position
-        """
-        if self.nominal_position is not None:
-            logger.debug("Moving {} to nominal aligned position"
-                         "".format(self.name))
-            self.move(self.nominal_position, wait=True)
-        super().stage()
-
     @limits.setter
     def limits(self, value):
         """

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -381,15 +381,6 @@ class PIMMotor(Device, PositionerBase):
         """
         return self.states.value == 'YAG'
 
-
-    def stage(self):
-        self.move_in(wait=True)
-        return super().stage()
-
-    def unstage(self):
-        self.move_out(wait=False)
-        return super().unstage()
-
     @property
     def timeout(self):
         return self.states.timeout

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -231,6 +231,7 @@ class PIMMotor(Device, PositionerBase):
                          configuration_attrs=configuration_attrs, name=name,
                          parent=parent, timeout=timeout, **kwargs)
         self.timeout = timeout
+        self.stage_cache_position = None
 
     def move_in(self, wait=False, **kwargs):
         """
@@ -396,6 +397,15 @@ class PIMMotor(Device, PositionerBase):
 
     def clear_sub(self, *args, **kwargs):
         self.states.clear_sub(*args, **kwargs)
+
+    def stage(self):
+        self.stage_cache_position = self.position
+        return super().stage()
+
+    def unstage(self):
+        if self.stage_cache_position is not None:
+            self.move(self.stage_cache_position, wait=False)
+        return super().unstage()
 
 
 class PIM(PIMMotor):

--- a/tests/test_sim_mirror.py
+++ b/tests/test_sim_mirror.py
@@ -28,11 +28,6 @@ def test_OMMotor_runs_ophyd_functions():
     assert(isinstance(ommotor.describe_configuration(), OrderedDict))
     assert(isinstance(ommotor.read_configuration(), OrderedDict))
 
-def test_OMMotor_stages():
-    ommotor = OMMotor("TEST", nominal_position=42.0)
-    ommotor.stage()
-    assert ommotor.position == 42.0
-
 def test_OMMotor_moves_properly():
     ommotor = OMMotor("TEST")
     status = ommotor.move(10)

--- a/tests/test_sim_pim.py
+++ b/tests/test_sim_pim.py
@@ -180,6 +180,8 @@ def test_PIMMotor_stage():
     pim = PIMMotor("TEST", pos_in=5)
     pim.move_out(wait=True)
     pim.stage()
+    assert(pim.position == "OUT")
+    pim.move_in(wait=True)
     assert(pim.position == "IN")
     pim.unstage()
     time.sleep(0.2)


### PR DESCRIPTION
If device setup is not fast, we need to explicitly do it in our plan to avoid jamming the RunEngine. To this end, we're removing the move wait=True calls from all stage methods, replacing them with save/restore where appropriate.