### PR TITLE
Small bugfixes

### DIFF
--- a/pcdsdevices/epics/areadetector/plugins.py
+++ b/pcdsdevices/epics/areadetector/plugins.py
@@ -67,6 +67,8 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
     def stage(self):
         # Ensure the plugin is enabled. We do not disable it on unstage
         if self.enable not in self.stage_sigs:
+            if not self.enable.connected:
+                self.enable.get()
             set_and_wait(self.enable, 1)
         ADBase.stage(self)
 


### PR DESCRIPTION
I encountered some small things to fix while testing the gui stability.

- AD staging: for the image plugin, stage() would fail on the first call sometimes because the enable PV was not connected prior to the call, and the set_and_wait call runs through a raise_if_disconnected wrapper somewhere early in the stack. We should investigate if this is a bug fixed in the newest Opyhd or if we should submit a suitable PR to address it, but for now I'll just make sure it's connected before proceeding.
- Slit motion: there is a bug in the slits IOC where the EPICS put callback doesn't happen until motion is complete. This means that the put(wait=True) call in PVPositioner was causing the RunEngine to jam up during any slit move, and it also means that our slit moves couldn't do both vertical and horizontal at the same time. I've set the put to wait=False in the SlitPositioner subclass to address the IOC oddity.
- Slit staging: there is another bug in the slits IOC where one cannot set the width and center locations at the same time, the calls will interrupt each other. This was causing our unstage() method to fail for the real device. To address this, I removed the save/restore on the slit center position, with the understanding that this position probably shouldn't be changed by us ever.