### PR TITLE
ENH: Fully overrided the limits properties and check_value to use soft limits

### DIFF
--- a/pcdsdevices/epics/epicsmotor.py
+++ b/pcdsdevices/epics/epicsmotor.py
@@ -32,8 +32,8 @@ class EpicsMotor(EpicsMotor, Device):
     """
     Epics motor for PCDS.
     """
-    llm = Component(EpicsSignal, ".LLM")
-    hlm = Component(EpicsSignal, ".HLM")
+    low_soft_limit = Component(EpicsSignal, ".LLM")
+    high_soft_limit = Component(EpicsSignal, ".HLM")
     offset_val = Component(EpicsSignal, ".OFF")
     direction_enum = Component(EpicsSignal, ".DIR")
 
@@ -47,7 +47,7 @@ class EpicsMotor(EpicsMotor, Device):
         low_limit : float
             The lower soft limit of the motor.
         """
-        return self.llm.value 
+        return self.low_soft_limit.value 
     
     @low_limit.setter
     def low_limit(self, value):
@@ -59,7 +59,7 @@ class EpicsMotor(EpicsMotor, Device):
         status : StatusObject
             Status object of the set.
         """
-        return self.llm.set(value)
+        return self.low_soft_limit.set(value)
 
     @property
     def high_limit(self):
@@ -71,7 +71,7 @@ class EpicsMotor(EpicsMotor, Device):
         high_limit : float
             The higher soft limit of the motor.
         """
-        return self.hlm.value     
+        return self.high_soft_limit.value     
 
     @high_limit.setter
     def high_limit(self, value):
@@ -83,7 +83,7 @@ class EpicsMotor(EpicsMotor, Device):
         status : StatusObject
             Status object of the set.
         """
-        return self.hlm.set(value)
+        return self.high_soft_limit.set(value)
 
     @property
     def limits(self):

--- a/pcdsdevices/epics/epicsmotor.py
+++ b/pcdsdevices/epics/epicsmotor.py
@@ -10,6 +10,7 @@ from enum import Enum
 # Third Party #
 ###############
 from ophyd import EpicsMotor
+from ophyd.utils import LimitError
 
 ##########
 # Module #
@@ -36,7 +37,19 @@ class EpicsMotor(EpicsMotor, Device):
     offset_val = Component(EpicsSignal, ".OFF")
     direction_enum = Component(EpicsSignal, ".DIR")
 
-    @EpicsMotor.low_limit.setter
+    @property
+    def low_limit(self):
+        """
+        Returns the lower soft limit for the motor.
+
+        Returns
+        -------
+        low_limit : float
+            The lower soft limit of the motor.
+        """
+        return self.llm.value 
+    
+    @low_limit.setter
     def low_limit(self, value):
         """
         Sets the low limit for the motor.
@@ -48,7 +61,19 @@ class EpicsMotor(EpicsMotor, Device):
         """
         return self.llm.set(value)
 
-    @EpicsMotor.high_limit.setter
+    @property
+    def high_limit(self):
+        """
+        Returns the higher soft limit for the motor.
+
+        Returns
+        -------
+        high_limit : float
+            The higher soft limit of the motor.
+        """
+        return self.hlm.value     
+
+    @high_limit.setter
     def high_limit(self, value):
         """
         Sets the high limit for the motor.
@@ -60,7 +85,19 @@ class EpicsMotor(EpicsMotor, Device):
         """
         return self.hlm.set(value)
 
-    @EpicsMotor.limits.setter
+    @property
+    def limits(self):
+        """
+        Returns the soft limits of the motor.
+
+        Returns
+        -------
+        limits : tuple
+            Soft limits of the motor.
+        """
+        return (self.low_limit, self.high_limit)
+    
+    @limits.setter
     def limits(self, limits):
         """
         Sets the limits for the motor.
@@ -70,8 +107,8 @@ class EpicsMotor(EpicsMotor, Device):
         limits : tuple
             Desired low and high limits.
         """
-        self.llm.set(limits[0])
-        self.hlm.set(limits[1])
+        self.low_limit = limits[0]
+        self.high_limit = limits[1]
 
     def set_limits(self, llm, hlm):
         """
@@ -86,6 +123,26 @@ class EpicsMotor(EpicsMotor, Device):
             Desired low limit.
         """        
         self.limits = (llm, hlm)
+
+    def check_value(self, value):
+        """
+        Check if the value is within the soft limits of the motor.
+
+        Raises
+        ------
+        ValueError
+        """
+        # Check for control limits on the user_setpoint pv
+        super().check_value(value)
+
+        if value is None:
+            raise ValueError('Cannot write None to epics PVs')
+
+        low_limit, high_limit = self.limits
+        
+        if not (low_limit <= value <= high_limit):
+            raise LimitError("Value {} outside of range: [{}, {}]"
+                             .format(value, low_limit, high_limit))
 
     @property
     def direction(self):


### PR DESCRIPTION
The default implementation of the limits was returning the lower and upper control limit for the `user_setpoint` signal. I changed it to actually return the limits from the `low_soft_limit` and 'high_soft_limit` signals. This makes interacting with the limits more transparent and easier to work with (when simulating at least).

I also overrode the `check_value` method to also check the soft limits of the motor rather than just the `user_setpoint` limits.