### PR TITLE
FIX: Default args on all_in so it works at all

### DIFF
--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -210,7 +210,7 @@ class BasicAttenuatorBase(IocDevice):
         return filters
 
 
-    def all_in(self):
+    def all_in(self, wait=False, timeout=30):
         """
         Move all filters to the "IN" position.
         """


### PR DESCRIPTION
Found before the run this morning, the all_in function on the attenuators doesn't work because values are missing for a boolean `wait` and a numeric `timeout`