### PR TITLE
CI: Check for DOCTR deploy key before moving forward.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - set -e
   #Build docs
   - |
-    if [ $BUILD_DOCS ]; then
+    if [ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]; then
       pip install -r docs-requirements.txt
       # Install doctr from a custom branch until
       # https://github.com/drdoctr/doctr/pull/190 is merged.


### PR DESCRIPTION
Attn. @teddyrendahl.
This should fix the issue that we were seeing...
It worked for at master: https://travis-ci.org/hhslepicka/pcds-devices/jobs/277045716