### PR TITLE
Warn user if att unstage fails

### DIFF
--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -211,7 +211,7 @@ class BasicAttenuatorBase(IocDevice):
         return filters
 
 
-    def all_in(self, wait=False, timeout=30):
+    def all_in(self, wait=False, timeout=10):
         """
         Move all filters to the "IN" position.
         """
@@ -230,7 +230,7 @@ class BasicAttenuatorBase(IocDevice):
         return status
 
 
-    def all_out(self, wait=False, timeout=None):
+    def all_out(self, wait=False, timeout=10):
         """
         Move all filters to the "OUT" position.
         """

--- a/pcdsdevices/sim/mirror.py
+++ b/pcdsdevices/sim/mirror.py
@@ -230,6 +230,7 @@ class OffsetMirror(mirror.OffsetMirror, SimDevice):
 
     # Placeholder signals for non-implemented components
     piezo = Component(FakeSignal)
+    mps = Component(FakeSignal)
 
     # Simulation component
     sim_alpha = Component(FakeSignal)


### PR DESCRIPTION
Simple fix to what we saw at the last beam time. When unstaging the attenuator, put a callback that logs if we have a failure. At the same time, I've dropped the default timeouts to 10s on all_in and all_out, because this is how long it will take for the status to be marked as failed.

As an aside, I've patched the sim object for OffsetMirror to mask the real mps PVs that were added. These PVs are causing a pswalker test to fail at the moment. The sim module could use a rework for stuff like this to avoid this kind of issue so we don't have to keep manually constructing the sim devices for PVs that have nothing interesting to simulate.