### PR TITLE
FIX: Add state as a Fake Signal at sim/OffsetMirror

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,5 +26,5 @@ test:
 
 about:
   home: https://github.com/slaclab/pcds-devices
-  license: SLAC Open Licence
+  license: SLAC Open License
   summary: IOC definitions for LCLS Beamline Devices

--- a/pcdsdevices/sim/mirror.py
+++ b/pcdsdevices/sim/mirror.py
@@ -231,6 +231,7 @@ class OffsetMirror(mirror.OffsetMirror, SimDevice):
     # Placeholder signals for non-implemented components
     piezo = Component(FakeSignal)
     mps = Component(FakeSignal)
+    state = Component(FakeSignal)
 
     # Simulation component
     sim_alpha = Component(FakeSignal)


### PR DESCRIPTION
@teddyrendahl this makes pswalker tests pass...
We can think of a better approach for the optional state & mps soon.