### PR TITLE
FIX: Check if slits are staged before unstaging

### DIFF
--- a/pcdsdevices/epics/slits.py
+++ b/pcdsdevices/epics/slits.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from ophyd.device import Staged
 from ophyd.pv_positioner import PVPositioner
 
 from .signal import EpicsSignal, EpicsSignalRO
@@ -214,8 +215,9 @@ class Slits(IocDevice):
         @stage_wrapper to make plans involving the slits to return to their
         starting positions.
         """
-        self.xwidth.move(self.stage_cache_xwidth,wait=False)
-        self.ywidth.move(self.stage_cache_ywidth,wait=False)
+        if self._staged = Staged.yes:
+            self.xwidth.move(self.stage_cache_xwidth,wait=False)
+            self.ywidth.move(self.stage_cache_ywidth,wait=False)
         return super().unstage()
 
     def open(self):

--- a/pcdsdevices/epics/slits.py
+++ b/pcdsdevices/epics/slits.py
@@ -215,7 +215,7 @@ class Slits(IocDevice):
         @stage_wrapper to make plans involving the slits to return to their
         starting positions.
         """
-        if self._staged = Staged.yes:
+        if self._staged == Staged.yes:
             self.xwidth.move(self.stage_cache_xwidth,wait=False)
             self.ywidth.move(self.stage_cache_ywidth,wait=False)
         return super().unstage()


### PR DESCRIPTION
Fixes an issue where if there is a problem in staging some other device, this one is unaffected on `unstage`.