### PR TITLE
FIX: Remove MPS and states record from OffsetMirror

### DIFF
--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -210,7 +210,7 @@ class DeviceStatesRecord(State, PositionerBase):
 
         if wait:
             status_wait(status)
-
+        
         return status
 
     def check_value(self, value):
@@ -390,8 +390,8 @@ class StateStatus(SubscriptionStatus):
                  timeout=None, settle_time=None):
         #Make a quick check_state callable
         def check_state(*args, **kwargs):
-            print(device.value, desired_state)
             return device.value == desired_state
+        
         #Start timeout and subscriptions
         super().__init__(device, check_state, event_type=device.SUB_STATE,
                          timeout=timeout, settle_time=settle_time)

--- a/tests/test_epics_mirror.py
+++ b/tests/test_epics_mirror.py
@@ -10,22 +10,16 @@ import pytest
 ##########
 # Module #
 ##########
-from pcdsdevices.epics.mirror import OffsetMirror
+from pcdsdevices.epics.mirror import PointingMirror
 from pcdsdevices.sim.pv       import using_fake_epics_pv
 
 @using_fake_epics_pv
 @pytest.fixture(scope='function')
 def branching_mirror():
-    m = OffsetMirror("MIRR:TST:M1H", "GANTRY:TST:M1H",
+    m = PointingMirror("MIRR:TST:M1H", "GANTRY:TST:M1H",
                      mps="MIRR:M1H:MPS", state_prefix="TST:M1H",
                      in_lines=['MFX', 'MEC'], out_lines= ['CXI'])
-    return m
-
-@using_fake_epics_pv
-@pytest.fixture(scope='function')
-def inline_mirror():
-    m = OffsetMirror("MIRR:TST:M1H", "GANTRY:TST:M1H",
-                     mps="MIRR:M1H:MPS", db_info={'beamline' : 'FEE'})
+    m.state.state._read_pv.enum_strs = ['IN', 'OUT']
     return m
 
 @using_fake_epics_pv
@@ -35,13 +29,21 @@ def test_branching_mirror(branching_mirror):
     assert branching_mirror.destination == []
     #Inserted
     branching_mirror.state.in_state.at_state._read_pv.put(1)
+    assert branching_mirror.inserted
     assert branching_mirror.destination == ['MFX', 'MEC']
     #Removed
     branching_mirror.state.out_state.at_state._read_pv.put(1)
     branching_mirror.state.in_state.at_state._read_pv.put(0)
+    assert branching_mirror.removed
     assert branching_mirror.destination == ['CXI']
 
 @using_fake_epics_pv
-def test_inline_mirror(inline_mirror):
-    assert inline_mirror.branches == ['FEE']
-    assert inline_mirror.destination == ['FEE']
+def test_branching_mirror_moves(branching_mirror):
+    #Test removal
+    branching_mirror.remove()
+    assert branching_mirror.state.state._write_pv.value == 'OUT'
+    #Finish simulated move manually
+    branching_mirror.state.state._read_pv.put('OUT')
+    #Insert 
+    branching_mirror.insert()
+    assert branching_mirror.state.state._write_pv.value == 'IN'


### PR DESCRIPTION
This should fix the bug that stopped the last run. The issue was I added `mps` and `states` components to the OffsetMirror. This was fine when loading the class and playing around, but when bluesky "stages" the mirror it goes through the tree of components and subcomponents calling stage on everything. This failed when attempting to stage these misconfigured components. The long term issue is not all the mirrors have MPS inputs or state summaries. 

We now have two separate classes for mirrors,`PointingMirror` and `OffsetMirror`. The ladder is for mirrors like the HOMS and XRT M3 where they are necessary for alignment but not necessarily steering between different beamlines. `PointingMirror` is for mirrors that when inserted or removed actually change which beamline gets photons delivered to it. It is expected that these mirrors have MPS inputs and an EPICS record that summarizes the state. Currently XRT M1 does not have MPS, but it really should, so it seems like that should be the next issue we address instead of making another class for the mirrors. 