### PR TITLE
FIX: Happi kwargs and remove ophyd Component

### DIFF
--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -22,12 +22,13 @@ class Device(ophyd.Device, metaclass=LightInterface):
     transmission = 0.0
     def __init__(self, prefix, **kwargs):
         db_info = kwargs.pop("db_info", None)
+        #Create mandatory lightpath attributes from Happi Information
+        #Placing None as default
+        for key in LIGHTPATH_KWARGS:
+            setattr(self, key, kwargs.pop(key, None))
+        #Store happi information if provided 
         if db_info:
             self.db = HappiData(db_info)
-            #Create mandatory lightpath attributes from Happi Information
-            #Placing None as default
-            for key in LIGHTPATH_KWARGS:
-                setattr(self, key, kwargs.get(key, None))
             for key in list(kwargs.keys()):
                 # Remove keys in kwargs if they were from the happi import but
                 # they cannot be passed to ophyd.Device

--- a/pcdsdevices/epics/areadetector/plugins.py
+++ b/pcdsdevices/epics/areadetector/plugins.py
@@ -8,10 +8,11 @@ import logging
 
 import ophyd
 import numpy as np
-from ophyd.device import GenerateDatumInterface, Component as C
+from ophyd.device import GenerateDatumInterface
 from ophyd.signal import EpicsSignal
 from ophyd.utils import set_and_wait
 from .base import ADBase
+from ...component import Component as C
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -10,6 +10,7 @@ from ophyd import Device
 ##########
 # Module #
 ##########
+import pcdsdevices
 from pcdsdevices.interface import MPSInterface, BranchingInterface, LightInterface
 
 class BasicDevice(Device, metaclass=LightInterface):
@@ -150,7 +151,7 @@ def test_basic_interface():
     device = BasicDevice("base")
     #Check that our class is a LightInterface type 
     assert type(BasicDevice) == LightInterface
-    #Check that the device is an ophyd device
+    #Check that the device is a pcdsdevice
     assert isinstance(device, Device)
 
 
@@ -158,7 +159,7 @@ def test_branching_interface():
     device = BasicBranching("base")
     #Check that our class is a LightInterface type 
     assert type(BasicBranching) == BranchingInterface
-    #Check that the device is an ophyd device
+    #Check that the device is a pcdsdevice
     assert isinstance(device, Device)
 
 
@@ -167,4 +168,11 @@ def test_mps_interface():
     #Check that our class is a LightInterface type 
     assert type(MPS) == MPSInterface
     #Check that the device is an ophyd device
-    assert isinstance(device, Device) 
+    #It can not be a pcdsdevices because this uses LightInterface
+    assert isinstance(device, Device)
+
+def test_device_metadata():
+    d = pcdsdevices.device.Device('Tst:Device', beamline='TST', z=10.0)
+    assert d.beamline == 'TST'
+    assert d.z == 10.0
+


### PR DESCRIPTION
Few quick fixes
---------------
* Lightpath kwargs should be searched for, even if `db_info` is not provided
* AreaDetector plugin should use `pcdsdevices.Component`