### PR TITLE
ENH: DAQ device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov
 .cache
 
 *.egg-info
+debug.log*

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pip wheel happi ophyd==0.6.1 pytest -c conda-forge -c lightsource2-tag -c skywalker-dev
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION coverage pip wheel happi ophyd==0.6.1 bluesky=0.9.0 pytest pytest-timeout -c conda-forge -c lightsource2-tag -c skywalker-dev
   #Launch Conda environment
   - source activate test-environment
   #Install mongomock

--- a/docs/source/daq.rst
+++ b/docs/source/daq.rst
@@ -1,0 +1,5 @@
+DAQ
+---
+
+.. autoclass:: pcdsdevices.daq.Daq
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@
    slits.rst
    pim.rst
    ipimb.rst
+   daq.rst
 
 .. toctree::
    :maxdepth: 1

--- a/pcdsdevices/__init__.py
+++ b/pcdsdevices/__init__.py
@@ -2,9 +2,6 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-#import logging # NOQA
-#logging.basicConfig(level=logging.INFO)
-#logger = logging.getLogger(__name__)
 import warnings
 from .device import Device # NOQA
 

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -194,7 +194,7 @@ class Daq(FlyerInterface):
         begin_status = DaqStatus(obj=self)
         watcher = threading.Thread(target=start_thread,
                                    args=(self.control, begin_status, events,
-                                         duration))
+                                         duration, use_l3t))
         watcher.start()
         return begin_status
 

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -9,9 +9,13 @@ import logging
 
 from ophyd.status import Status
 from ophyd.flyers import FlyerInterface
-import pydaq
 
 logger = logging.getLogger(__name__)
+
+try:
+    import pydaq
+except:
+    logger.warning('pydaq not in environment. Will not be able to use DAQ!')
 
 
 class Daq(FlyerInterface):

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -291,6 +291,7 @@ class Daq(FlyerInterface):
             self.config = None
             msg = 'Failed to configure!'
             logger.exception(msg)
+            return old, {}
         new = self.read_configuration()
         return old, new
 

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -184,7 +184,7 @@ class Daq(FlyerInterface):
         logger.debug('Daq.kickoff()')
 
         def start_thread(control, status, events, duration, use_l3t):
-            if any(map(lambda x: x is not None, events, duration)):
+            if any(map(lambda x: x is not None, (events, duration))):
                 kwargs = self._parse_config_args(events, duration, use_l3t)
                 control.begin(**kwargs)
             else:

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -77,7 +77,6 @@ class Daq(FlyerInterface):
 
     @property
     def state(self):
-        logger.debug('accessing Daq.state')
         if self.connected:
             num = self.control.state()
             return self.state_enum(num).name
@@ -300,9 +299,11 @@ class Daq(FlyerInterface):
         old = self.read_configuration()
         config_args = self._config_args(record, use_l3t, controls)
         try:
+            logger.debug('Calling Control.configure with kwargs %s',
+                         config_args)
+            self.control.configure(**config_args)
             # self.config should reflect exactly the arguments to configure,
             # this is different than the arguments that pydaq.Control expects
-            self.control.configure(**config_args)
             self.config = dict(events=events, duration=duration,
                                record=record, use_l3t=use_l3t,
                                controls=controls)
@@ -328,7 +329,7 @@ class Daq(FlyerInterface):
                      record, use_l3t, controls)
         config_args = {}
         for key, val in zip(('record', 'controls'),
-                            (record, use_l3t, controls)):
+                            (record, controls)):
             if val is None:
                 if self.config is None:
                     config_args[key] = self.default_config[key]
@@ -340,6 +341,9 @@ class Daq(FlyerInterface):
             config_args['l3t_events'] = 0
         else:
             config_args['events'] = 0
+            for key, value in list(config_args.items()):
+                if value is None:
+                    del config_args[key]
         return config_args
 
     def _begin_args(self, events, duration, use_l3t, controls):

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -390,7 +390,7 @@ class Daq(FlyerInterface):
 
 class DaqStatus(Status):
     def wait(self, timeout=None):
-        self._wait_done = threading.RLock()
+        self._wait_done = threading.Event()
 
         def cb(*args, **kwargs):
             self._wait_done.set()

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 import os
 import functools
+import threading
+import copy
+import enum
 import logging
 
-from ophyd.status import StatusBase
+from ophyd.status import Status
 from ophyd.flyers import FlyerInterface
 import pydaq
 
@@ -22,6 +25,10 @@ class Daq(FlyerInterface):
     Unlike a normal bluesky flyer, this has no data to report to the RunEngine
     on the collect call. No data will pass into the python layer from the daq.
     """
+    state_enum = enum.Enum("pydaq state",
+                           "Disconnected Connected Configured Open Running",
+                           start=0)
+
     def __init__(self, name, platform=0, parent=None):
         super().__init__()
         self.name = name
@@ -39,6 +46,14 @@ class Daq(FlyerInterface):
     @property
     def configured(self):
         return self.config is not None
+
+    @property
+    def state(self):
+        if self.connected:
+            num = self.control.state()
+            return self.state_enum(num).name
+        else:
+            return "Disconnected"
 
     # Wrapper to make sure we're connected
     def check_connect(f):
@@ -99,27 +114,46 @@ class Daq(FlyerInterface):
         """
         Pause the thread until the DAQ is done aquiring.
         """
-        pass
+        status = self.complete()
+        status.wait()
 
     @check_config
-    def begin(self):
+    def begin(self, events=None, duration=None, wait=False):
         """
-        Start the daq with the current configuration. Block until the daq has
-        begun acquiring data.
-        """
-        pass
+        Start the daq with the current configuration. Block until
+        the daq has begun acquiring data. Optionally block until the daq has
+        finished aquiring data.
 
-    # Utility methods
-    def _end_status(self):
-        """
-        Return a status object that will be marked as 'done' when the DAQ has
-        finished acquiring.
+        Parameters
+        ----------
+        events: int, optional
+            Number events to stop acquisition at.
 
-        Returns
-        -------
-        done_status: StatusBase
+        duration: int, optional
+            Time to run the daq in seconds.
+
+        wait: bool, optional
+            If switched to True, wait for the daq to finish aquiring data.
         """
-        pass
+        begin_status = self.kickoff()
+        begin_status.wait()
+        if wait:
+            self.wait()
+
+    @check_connect
+    def stop(self):
+        """
+        Stop the current acquisition, ending it early.
+        """
+        self.control.stop()
+
+    @check_connect
+    def end_run(self):
+        """
+        Stop the daq if it's running, then mark the run as finished.
+        """
+        self.stop()
+        self.control.endrun()
 
     # Flyer interface
     @check_config
@@ -129,22 +163,36 @@ class Daq(FlyerInterface):
 
         Returns
         -------
-        ready_status: StatusBase
+        ready_status: DaqStatus
             Status that will be marked as 'done' when the daq has begun to
             record data.
         """
-        pass
+        def start_thread(control, status):
+            control.begin()
+            status._finished(success=True)
+        begin_status = DaqStatus(obj=self)
+        watcher = threading.Thread(target=start_thread,
+                                   args=(self.control, begin_status))
+        watcher.start()
+        return begin_status
 
     def complete(self):
         """
-        Returns a status that will be marked done when acquisition has been
-        completed.
+        Return a status object that will be marked as 'done' when the DAQ has
+        finished acquiring.
 
         Returns
         -------
-        complete_status: StatusBase
+        end_status: DaqStatus
         """
-        pass
+        def finish_thread(control, status):
+            control.end()
+            status._finished(success=True)
+        end_status = DaqStatus(obj=self)
+        watcher = threading.Thread(target=finish_thread,
+                                   args=(self.control, end_status))
+        watcher.start()
+        return end_status
 
     def collect(self):
         """
@@ -157,24 +205,73 @@ class Daq(FlyerInterface):
     def describe_collect(self):
         """
         As per the bluesky interface, this is how you interpret the null data
-        from collect. There isn't anything here.
+        from collect. There isn't anything here, as nothing will be collected.
         """
         return {}
 
     @check_connect
-    def configure(self, *args, **kwargs):
+    def configure(self, events=None, duration=None, use_l3t=False,
+                  record=False, controls=None):
         """
         Changes the daq's configuration for the next run.
 
         Parameters
         ----------
-        TODO Fill this in
+        events: int, optional
+            If provided, the daq will run for this many events before stopping.
+            If not provided, we'll use the duration argument instead.
+
+        duration: int, optional
+            If provided, the daq will run for this many seconds before
+            stopping. If not provided, and events was also not provided, an
+            error will be raised.
+
+        use_l3t: bool, optional
+            If True, the events argument will be reinterpreted to only count
+            events that pass the level 3 trigger.
+
+        record: bool, optional
+            If True, we'll record the data. Otherwise, we'll run without
+            recording.
+
+        controls: list of tuple(str, value), optional
+            If provided, these will make it into the data stream as control
+            variables.
 
         Returns
         -------
         old, new: tuple of dict
         """
-        pass
+        if self.config is None:
+            old = {}
+        else:
+            old = self.read_configuration()
+        config_args = {}
+        if events is not None:
+            if use_l3t:
+                config_args['l3t_events'] = events
+            else:
+                config_args['events'] = events
+        elif duration is not None:
+            config_args['duration'] = duration
+        else:
+            raise RuntimeError('Either events or duration must be provided.')
+        config_args['record'] = record
+        if controls is not None:
+            config_args['controls'] = controls
+        try:
+            # self.config should reflect exactly the arguments to configure,
+            # this is different than the arguments that pydaq.Control expects
+            self.control.configure(**config_args)
+            self.config = dict(events=events, duration=duration,
+                               use_l3t=use_l3t, record=record,
+                               controls=controls)
+        except:
+            self.config = None
+            msg = 'Failed to configure!'
+            logger.exception(msg)
+        new = self.read_configuration()
+        return old, new
 
     @check_config
     def read_configuration(self):
@@ -184,7 +281,7 @@ class Daq(FlyerInterface):
         config: dict
             Mapping of config key to current configured value.
         """
-        pass
+        return copy.deepcopy(self.config)
 
     def describe_configuration(self):
         """
@@ -193,7 +290,26 @@ class Daq(FlyerInterface):
         config_desc: dict
             Mapping of config key to field metadata.
         """
-        pass
+        try:
+            config = self.read_configuration()
+            controls_shape = [len(config['control']), 2]
+        except (RuntimeError, AttributeError):
+            controls_shape = None
+        return dict(events=dict(source='daq_events_in_run',
+                                dtype='number',
+                                shape=None),
+                    duration=dict(source='daq_run_duration',
+                                  dtype='number',
+                                  shape=None),
+                    use_l3t=dict(source='daq_use_l3trigger',
+                                 dtype='number',
+                                 shape=None),
+                    record=dict(source='daq_record_run',
+                                dtype='number',
+                                shape=None),
+                    controls=dict(source='daq_control_vars',
+                                  dtype='array',
+                                  shape=controls_shape))
 
     def unstage(self):
         """
@@ -204,16 +320,29 @@ class Daq(FlyerInterface):
         unstaged: list
             list of devices unstaged
         """
-        pass
+        self.end_run()
+        return super().unstage()
 
     def pause(self):
         """
         Stop acquiring data, but don't end the run.
         """
-        pass
+        if self.state == 'Running':
+            self.stop()
 
     def resume(self):
         """
         Continue acquiring data in a previously paused run.
         """
-        pass
+        if self.state == 'Open':
+            self.begin()
+
+
+class DaqStatus(Status):
+    def wait(self, timeout=None):
+        self._wait_done = threading.RLock()
+
+        def cb(*args, **kwargs):
+            self._wait_done.set()
+        self.finished_cb = cb
+        self._wait_done.wait(timeout=timeout)

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import functools
+import logging
+
+from ophyd.status import StatusBase
+from ophyd.flyers import FlyerInterface
+import pydaq
+
+logger = logging.getLogger(__name__)
+
+
+class Daq(FlyerInterface):
+    """
+    The LCLS1 DAQ as a flyer object. This uses the pydaq module to connect with
+    a running daq instance, controlling it via socket commands. It can be used
+    as a flyer in a bluesky plan to have the daq start at the beginning of the
+    run and end at the end of the run. It has additional knobs for pausing
+    and resuming acquisition if desired.
+
+    Unlike a normal bluesky flyer, this has no data to report to the RunEngine
+    on the collect call. No data will pass into the python layer from the daq.
+    """
+    def __init__(self, name, platform=0, parent=None):
+        super().__init__()
+        self.name = name
+        self.parent = parent
+        self.control = None
+        self.config = None
+        self._host = os.uname()[1]
+        self._plat = platform
+
+    # Convenience properties
+    @property
+    def connected(self):
+        return self.control is not None
+
+    @property
+    def configured(self):
+        return self.config is not None
+
+    # Wrapper to make sure we're connected
+    def check_connect(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            if not self.connected:
+                msg = 'DAQ is not connected. Attempting to connect...'
+                logger.info(msg)
+                self.connect()
+            if self.connected:
+                return f(self, *args, **kwargs)
+            else:
+                raise RuntimeError('Could not connect to DAQ.')
+        return wrapper
+
+    # Wrapper to make sure we've configured
+    def check_config(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            if self.configured:
+                return f(self, *args, **kwargs)
+            else:
+                raise RuntimeError('DAQ is not configured.')
+        return wrapper
+
+    # Interactive methods
+    def connect(self):
+        """
+        Connect to the DAQ instance, giving full control to the Python process.
+        """
+        if self.control is None:
+            try:
+                self.control = pydaq.Control(self._host, platform=self._plat)
+                self.control.connect()
+                msg = 'Connected to DAQ'
+            except:
+                del self.control
+                self.control = None
+                msg = ('Failed to connect to DAQ - check that it is up and '
+                       'allocated.')
+        else:
+            msg = 'Connect requested, but already connected to DAQ'
+        logger.info(msg)
+
+    def disconnect(self):
+        """
+        Disconnect from the DAQ instance, giving control back to the GUI
+        """
+        if self.control is not None:
+            self.control.disconnect()
+        del self.control
+        self.control = None
+        self.config = None
+        logger.info('DAQ is disconnected.')
+
+    @check_connect
+    def wait(self):
+        """
+        Pause the thread until the DAQ is done aquiring.
+        """
+        pass
+
+    @check_config
+    def begin(self):
+        """
+        Start the daq with the current configuration. Block until the daq has
+        begun acquiring data.
+        """
+        pass
+
+    # Utility methods
+    def _end_status(self):
+        """
+        Return a status object that will be marked as 'done' when the DAQ has
+        finished acquiring.
+
+        Returns
+        -------
+        done_status: StatusBase
+        """
+        pass
+
+    # Flyer interface
+    @check_config
+    def kickoff(self):
+        """
+        Begin acquisition. This method is non-blocking.
+
+        Returns
+        -------
+        ready_status: StatusBase
+            Status that will be marked as 'done' when the daq has begun to
+            record data.
+        """
+        pass
+
+    def complete(self):
+        """
+        Returns a status that will be marked done when acquisition has been
+        completed.
+
+        Returns
+        -------
+        complete_status: StatusBase
+        """
+        pass
+
+    def collect(self):
+        """
+        As per the bluesky interface, this is a generator that is expected to
+        output partial event documents. However, since we don't have any events
+        to report to python, this will be a generator that immediately ends.
+        """
+        raise GeneratorExit
+
+    def describe_collect(self):
+        """
+        As per the bluesky interface, this is how you interpret the null data
+        from collect. There isn't anything here.
+        """
+        return {}
+
+    @check_connect
+    def configure(self, *args, **kwargs):
+        """
+        Changes the daq's configuration for the next run.
+
+        Parameters
+        ----------
+        TODO Fill this in
+
+        Returns
+        -------
+        old, new: tuple of dict
+        """
+        pass
+
+    @check_config
+    def read_configuration(self):
+        """
+        Returns
+        -------
+        config: dict
+            Mapping of config key to current configured value.
+        """
+        pass
+
+    def describe_configuration(self):
+        """
+        Returns
+        -------
+        config_desc: dict
+            Mapping of config key to field metadata.
+        """
+        pass
+
+    def unstage(self):
+        """
+        If the daq is running and the run has not ended, end it.
+
+        Returns
+        -------
+        unstaged: list
+            list of devices unstaged
+        """
+        pass
+
+    def pause(self):
+        """
+        Stop acquiring data, but don't end the run.
+        """
+        pass
+
+    def resume(self):
+        """
+        Continue acquiring data in a previously paused run.
+        """
+        pass

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -472,6 +472,8 @@ class Daq(FlyerInterface):
             self.begin()
 
     def __del__(self):
+        if self.state in ('Open', 'Running'):
+            self.end_run()
         self.disconnect()
 
 

--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -70,9 +70,12 @@ class Daq(FlyerInterface):
                 logger.info(msg)
                 self.connect()
             if self.connected:
+                logger.debug('Daq is connected')
                 return f(self, *args, **kwargs)
             else:
-                raise RuntimeError('Could not connect to DAQ.')
+                err = 'Could not connect to DAQ'
+                logger.error(err)
+                raise RuntimeError(err)
         return wrapper
 
     # Wrapper to make sure we've configured
@@ -81,9 +84,12 @@ class Daq(FlyerInterface):
         def wrapper(self, *args, **kwargs):
             logger.debug('Checking for daq config')
             if self.configured:
+                logger.debug('Daq is configured')
                 return f(self, *args, **kwargs)
             else:
-                raise RuntimeError('DAQ is not configured.')
+                err = 'DAQ is not configured'
+                logger.error(err)
+                raise RuntimeError(err)
         return wrapper
 
     # Interactive methods

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -88,7 +88,7 @@ class SimControl:
             thr = threading.Thread(target=self._begin_thread, args=())
             thr.start()
 
-    def _pick_duration(events, l1t_events, l3t_events, duration):
+    def _pick_duration(self, events, l1t_events, l3t_events, duration):
         for ev in (events, l1t_events, l3t_events):
             if ev is not None:
                 return ev / 120

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -57,7 +57,7 @@ class SimControl:
             return True
         else:
             err = 'Invalid SimControl transition {} from state {}'
-            raise RuntimeError(err.format(self._state, transition))
+            raise RuntimeError(err.format(transition, self._state))
 
     def state(self):
         return self._all_states.index(self._state)
@@ -109,8 +109,8 @@ class SimControl:
     def _begin_thread(self):
         self._done_flag.clear()
         while self._time_remaining > 0:
-            self._time_remaining -= 1
-            time.sleep(1)
+            self._time_remaining -= 0.1
+            time.sleep(0.1)
         try:
             self.stop()
         except:

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import time
+import threading
+import logging
+
+from pcdsdevices.daq import Daq
+
+logger = logging.getLogger()
+
+
+class SimDaq(Daq):
+    def connect(self):
+        logger.debug('SimDaq.connect()')
+        self.control = SimControl()
+        self.control.connect()
+        msg = 'Connected to sim DAQ'
+        logger.info(msg)
+
+
+class SimControl:
+    _state = all_states[0]
+    _all_states = ['Disconnected', 'Connected', 'Configured', 'Open',
+                   'Running']
+    _transitions = dict(
+        connect=dict(ignore=_all_states[1:],
+                     begin=[_all_states[0]],
+                     end=_all_states[1]),
+        disconnect=dict(ignore=[],
+                        begin=_all_states[0:3],
+                        end=_all_states[0]),
+        configure=dict(ignore=[],
+                       begin=_all_states[1:3],
+                       end=_all_states[2]),
+        begin=dict(ignore=[],
+                   begin=_all_states[2:4],
+                   end=_all_states[4]),
+        stop=dict(ignore=_all_states[0:4],
+                  begin=[_all_states[4]],
+                  end=_all_states[3]),
+        endrun=dict(ignore=_all_states[0:3],
+                    begin=_all_states[3:5],
+                    end=_all_states[2])
+    )
+    def __init__(self, *args, **kwargs):
+        self._duration = None
+        self._time_remaining = 0
+        self._done_flag = threading.Event()
+
+    def _do_transition(self, transition):
+        info = self._transitions[transition]
+        if self.state() in info['ignore']:
+            return False
+        elif self.state() in info['begin']:
+            self._state = info['end']
+            return True
+        else:
+            err = 'Invalid SimControl transition {} from state {}'
+            raise RuntimeError(err.format(self.state(), transition))
+
+    def state(self):
+        return self._state
+
+    def connect(self):
+        self._do_transition('connect')
+
+    def disconnect(self):
+        self._do_transition('disconnect')
+
+    def configure(self, *, record=False, key=0, events=None, l1t_events=None,
+                  l3t_events=None, duration=0, controls=None, monitors=None,
+                  partition=None):
+        if self._do_transition('configure'):
+            dur = self._pick_duration(events, l1t_events, l3t_events, duration)
+            if dur is None:
+                raise RuntimeError('configure requires events or duration')
+            else:
+                self._duration = dur
+
+    def begin(self, *, events=None, l1t_events=None, l3t_events=None,
+              duration=None, controls=None, monitors=None):
+        if self._do_transition('begin'):
+            dur = self._pick_duration(events, l1t_events, l3t_events, duration)
+            if dur is None:
+                dur = self._duration
+            self._time_remaining = dur
+            thr = threading.Thread(target=self._begin_thread, args=())
+            thr.start()
+
+    def _pick_duration(events, l1t_events, l3t_events, duration):
+        for ev in (events, l1t_events, l3t_events):
+            if ev is not None:
+                return 120 * ev
+            if duration is not None:
+                return duration
+            return None
+
+    def stop(self):
+        self._do_transition('stop')
+        self._time_remaining = 0
+        self._done_flag.set()
+
+    def endrun(self):
+        self._do_transition('endrun')
+        self._time_remaining = 0
+        self._done_flag.set()
+
+    def _begin_thread(self):
+        self._done_flag.clear()
+        while self._time_remaining > 0:
+            self._time_remaining -= 1
+            time.sleep(1)
+        try:
+            self.stop()
+        except:
+            pass
+
+    def end(self):
+        self._done_flag.wait()

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -6,7 +6,7 @@ import logging
 
 from pcdsdevices.daq import Daq
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class SimDaq(Daq):

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -49,6 +49,8 @@ class SimControl:
         self._done_flag = threading.Event()
 
     def _do_transition(self, transition):
+        logger.debug('Doing transition %s from state %s',
+                     transition, self._state)
         info = self._transitions[transition]
         if self._state in info['ignore']:
             return False
@@ -99,7 +101,7 @@ class SimControl:
                 err = 'SimControl stops here because pydaq segfaults here'
                 raise RuntimeError(err)
             self._done_flag.clear()
-            thr = threading.Thread(target=self._begin_thread, args=(dur))
+            thr = threading.Thread(target=self._begin_thread, args=(dur,))
             thr.start()
 
     def _pick_duration(self, events, l1t_events, l3t_events, duration):

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -19,9 +19,9 @@ class SimDaq(Daq):
 
 
 class SimControl:
-    _state = all_states[0]
     _all_states = ['Disconnected', 'Connected', 'Configured', 'Open',
                    'Running']
+    _state = _all_states[0]
     _transitions = dict(
         connect=dict(ignore=_all_states[1:],
                      begin=[_all_states[0]],
@@ -42,6 +42,7 @@ class SimControl:
                     begin=_all_states[3:5],
                     end=_all_states[2])
     )
+
     def __init__(self, *args, **kwargs):
         self._duration = None
         self._time_remaining = 0
@@ -49,17 +50,17 @@ class SimControl:
 
     def _do_transition(self, transition):
         info = self._transitions[transition]
-        if self.state() in info['ignore']:
+        if self._state in info['ignore']:
             return False
-        elif self.state() in info['begin']:
+        elif self._state in info['begin']:
             self._state = info['end']
             return True
         else:
             err = 'Invalid SimControl transition {} from state {}'
-            raise RuntimeError(err.format(self.state(), transition))
+            raise RuntimeError(err.format(self._state, transition))
 
     def state(self):
-        return self._state
+        return self._all_states.index(self._state)
 
     def connect(self):
         self._do_transition('connect')
@@ -90,7 +91,7 @@ class SimControl:
     def _pick_duration(events, l1t_events, l3t_events, duration):
         for ev in (events, l1t_events, l3t_events):
             if ev is not None:
-                return 120 * ev
+                return ev / 120
             if duration is not None:
                 return duration
             return None

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -98,9 +98,8 @@ class SimControl:
             if dur is None:
                 err = 'SimControl stops here because pydaq segfaults here'
                 raise RuntimeError(err)
-            self._time_remaining = dur
             self._done_flag.clear()
-            thr = threading.Thread(target=self._begin_thread, args=())
+            thr = threading.Thread(target=self._begin_thread, args=(dur))
             thr.start()
 
     def _pick_duration(self, events, l1t_events, l3t_events, duration):
@@ -128,13 +127,12 @@ class SimControl:
         self._time_remaining = 0
         self._done_flag.set()
 
-    def _begin_thread(self):
-        logger.debug('SimControl._begin_thread()')
-        logger.debug('%ss remaining', self._time_remaining)
+    def _begin_thread(self, duration):
+        logger.debug('SimControl._begin_thread(%s)', duration)
         start = time.time()
         interrupted = False
-        while self._time_remaining > 0:
-            self._time_remaining -= 0.1
+        while duration > 0:
+            duration -= 0.1
             if self._done_flag.wait(0.1):
                 interrupted = True
                 break
@@ -144,8 +142,8 @@ class SimControl:
             except:
                 pass
         end = time.time()
-        logger.debug('%ss elapased in SimControl._begin_thread()',
-                     end-start)
+        logger.debug('%ss elapased in SimControl._begin_thread(%s)',
+                     end-start, duration)
 
     def end(self):
         logger.debug('SimControl.end()')

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 import sys
+import os
+import logging
+from logging.handlers import TimedRotatingFileHandler
 import pytest
 
 if __name__ == '__main__':
@@ -11,13 +14,30 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
 
-    #Ignore live tests unless given the live keyword
+    # Ignore live tests unless given the live keyword
     if '--live' in args:
         args.remove('--live')
         args.append('tests_live')
     else:
         args.append('--ignore=tests_live')
 
-    print('pytest arguments: {}'.format(args))
+    txt = 'pytest arguments: {}'.format(args)
+    print(txt)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+    log_filename = os.path.join(os.path.dirname(__file__), 'debug.log')
+    handler = TimedRotatingFileHandler(log_filename, when='d', interval=1,
+                                       backupCount=7)
+    formatter = logging.Formatter(fmt=('%(asctime)s '
+                                       '%(name)-20s '
+                                       '%(levelname)-8s '
+                                       '%(message)s'),
+                                  datefmt='%m-%d %H:%M:%S')
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+
+    logger = logging.getLogger(__name__)
+    logger.info(txt)
 
     sys.exit(pytest.main(args))

--- a/run_tests.py
+++ b/run_tests.py
@@ -34,11 +34,11 @@ if __name__ == '__main__':
     handler = RotatingFileHandler(log_filename, backupCount=9)
     if do_rollover:
         handler.doRollover()
-    formatter = logging.Formatter(fmt=('%(asctime)s '
+    formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
                                        '%(name)-20s '
                                        '%(levelname)-8s '
                                        '%(message)s'),
-                                  datefmt='%m-%d %H:%M:%S')
+                                  datefmt='%H:%M:%S')
     handler.setFormatter(formatter)
     root_logger.addHandler(handler)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -35,8 +35,9 @@ if __name__ == '__main__':
     if do_rollover:
         handler.doRollover()
     formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
-                                       '%(name)-20s '
+                                       '%(module)-10s '
                                        '%(levelname)-8s '
+                                       '%(threadName)-10s '
                                        '%(message)s'),
                                   datefmt='%H:%M:%S')
     handler.setFormatter(formatter)

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import logging
-from logging.handlers import TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler
 import pytest
 
 if __name__ == '__main__':
@@ -27,8 +27,13 @@ if __name__ == '__main__':
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
     log_filename = os.path.join(os.path.dirname(__file__), 'debug.log')
-    handler = TimedRotatingFileHandler(log_filename, when='d', interval=1,
-                                       backupCount=7)
+    if os.path.isfile(log_filename):
+        do_rollover = True
+    else:
+        do_rollover = False
+    handler = RotatingFileHandler(log_filename, backupCount=9)
+    if do_rollover:
+        handler.doRollover()
     formatter = logging.Formatter(fmt=('%(asctime)s '
                                        '%(name)-20s '
                                        '%(levelname)-8s '

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -124,13 +124,15 @@ def test_run_flow(daq):
     assert daq.state == 'Running'
     daq.stop()
     assert daq.state == 'Open'
-    assert time.time() - t0 < 5
+    short_time = time.time() - t0
+    assert short_time < 5
     t1 = time.time()
     daq.begin(duration=2)
     assert daq.state == 'Running'
     daq.wait()
     assert daq.state == 'Open'
-    assert time.time() - t1 > 2
+    at_least_2_secs = time.time() - t1
+    assert at_least_2_secs > 2
     daq.begin(duration=60)
     assert daq.state == 'Running'
     daq.pause()

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -58,6 +58,8 @@ def test_configure(daq):
     assert not daq.connected
     assert not daq.configured
     daq.configure(events=1000)
+    assert daq.read_configuration()['events'] == 1000
+    assert daq.read_configuration()['duration'] == None
     assert daq.connected
     assert daq.configured
     daq.disconnect()
@@ -67,6 +69,8 @@ def test_configure(daq):
     assert daq.connected
     assert not daq.configured
     daq.configure(duration=60)
+    assert daq.read_configuration()['events'] == None
+    assert daq.read_configuration()['duration'] == 60
     assert daq.connected
     assert daq.configured
     configs = [

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -51,7 +51,8 @@ def test_configure(daq):
     We expect to be able to disconnect after a configure.
     We expect a connected daq to be able to configure.
     We expect configure to return both the old and new configurations.
-    We expect read_configure to give us the inputted configure arguments.
+    We expect read_configure to give us the current configuration, including
+    default args.
     We expect neglecting to provide both events and duration to raise an error.
     """
     assert not daq.connected
@@ -77,8 +78,9 @@ def test_configure(daq):
     for config in configs:
         old, new = daq.configure(**config)
         assert old == prev_config
-        assert new == config
-        assert daq.read_configuration() == config
+        assert daq.read_configuration() == new
+        for key, value in config.items():
+            assert new[key] == value
         prev_config = config
     with pytest.raises(RuntimeError):
         daq.configure()

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import time
+import pytest
+
+from bluesky import RunEngine
+from bluesky.examples import Reader
+from bluesky.plans import (fly_during_decorator, stage_decorator,
+                           run_decorator, trigger_and_read)
+
+from pcdsdevices.daq import Daq
+from pcdsdevices.sim.daq import SimDaq
+
+
+def test_instantiation():
+    realdaq = Daq() # NOQA
+    fakedaq = SimDaq() # NOQA
+
+
+@pytest.fixture(scope='function')
+def daq():
+    return SimDaq()
+
+
+def test_connect(daq):
+    """
+    We expect connect to bring the daq from a disconnected state to a connected
+    state.
+    """
+    assert not daq.connected
+    daq.connect()
+    assert daq.connected
+
+
+def test_disconnect(daq):
+    """
+    We expect disconnect to bring the daq from a connected state to a
+    disconnected state.
+    """
+    assert not daq.connected
+    daq.connect()
+    assert daq.connected
+    daq.disconnect()
+    assert not daq.connected
+
+
+def test_configure(daq):
+    """
+    We expect the configured attribute to be correct.
+    We expect a disconnected daq to connect and then configure.
+    We expect to be able to disconnect after a configure.
+    We expect a connected daq to be able to configure.
+    We expect configure to return both the old and new configurations.
+    We expect read_configure to give us the inputted configure arguments.
+    We expect neglecting to provide both events and duration to raise an error.
+    """
+    assert not daq.connected
+    assert not daq.configured
+    daq.configure(events=1000)
+    assert daq.connected
+    assert daq.configured
+    daq.disconnect()
+    assert not daq.connected
+    assert not daq.configured
+    daq.connect()
+    assert daq.connected
+    assert not daq.configured
+    daq.configure(duration=60)
+    assert daq.connected
+    assert daq.configured
+    configs = [
+        dict(events=1000, use_l3t=True),
+        dict(events=1000, use_l3t=True, record=True),
+        dict(duration=10, controls=[]),
+    ]
+    prev_config = dict(duration=60)
+    for config in configs:
+        old, new = daq.configure(**config)
+        assert old == prev_config
+        assert new == config
+        assert daq.read_configuration() == config
+        prev_config = config
+    with pytest.raises(RuntimeError):
+        daq.configure()
+
+
+def test_run_flow(daq):
+    """
+    We expect a begin without a configure to throw an error.
+    Otherwise, we expect the daq to run for the configured time, or the time
+    passed into begin.
+    We expect that the running stops early if we call stop.
+    We expect that we close the run upon calling end_run
+    We expect that wait will block the thread until the daq is no longer
+    running
+    """
+    with pytest.raises(RuntimeError):
+        daq.begin()
+    assert daq.state() == 'Disconnected'
+    daq.configure(duration=1)
+    assert daq.state() == 'Configured'
+    daq.begin()
+    assert daq.state() == 'Running'
+    time.sleep(1.1)
+    assert daq.state() == 'Open'
+    daq.begin(duration=2)
+    assert daq.state() == 'Running'
+    time.sleep(1.1)
+    assert daq.state() == 'Running'
+    time.sleep(1.1)
+    assert daq.state() == 'Open'
+    daq.end_run()
+    assert daq.state() == 'Configured'
+    daq.configure(duration=60)
+    t0 = time.time()
+    daq.begin()
+    assert daq.state() == 'Running'
+    daq.stop()
+    assert daq.state() == 'Open'
+    assert time.time() - t0 < 5
+    t1 = time.time()
+    daq.begin(duration=2)
+    assert daq.state() == 'Running'
+    daq.wait()
+    assert daq.state() == 'Open'
+    assert time.time() - t1 > 2
+    daq.begin(duration=60)
+    assert daq.state() == 'Running'
+    daq.pause()
+    assert daq.state() == 'Open'
+    daq.resume()
+    assert daq.state() == 'Running'
+    daq.end_run()
+    assert daq.state() == 'Configured'
+
+
+def test_scan(daq):
+    """
+    We expect that the daq object is usable in a bluesky plan.
+    """
+    RE = RunEngine({})
+    daq.connect()
+    daq.configure(duration=60, record=False)
+    assert daq.status() == 'Configured'
+
+    @fly_during_decorator([daq])
+    @stage_decorator([daq])
+    @run_decorator()
+    def plan(reader):
+        for i in range(10):
+            assert daq.status() == 'Running'
+            yield from trigger_and_read([reader])
+        assert daq.status() == 'Running'
+
+    RE(plan(Reader('test', {'zero': lambda: 0})))
+
+    assert daq.status() == 'Configured'

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import time
+import logging
 import pytest
 
 from bluesky import RunEngine
@@ -10,6 +11,8 @@ from bluesky.plans import (fly_during_decorator, stage_decorator,
 
 from pcdsdevices.daq import Daq
 from pcdsdevices.sim.daq import SimDaq
+
+logger = logging.getLogger(__name__)
 
 
 def test_instantiation():
@@ -27,6 +30,7 @@ def test_connect(daq):
     We expect connect to bring the daq from a disconnected state to a connected
     state.
     """
+    logger.debug('test_connect')
     assert not daq.connected
     daq.connect()
     assert daq.connected
@@ -37,6 +41,7 @@ def test_disconnect(daq):
     We expect disconnect to bring the daq from a connected state to a
     disconnected state.
     """
+    logger.debug('test_disconnect')
     assert not daq.connected
     daq.connect()
     assert daq.connected
@@ -55,6 +60,7 @@ def test_configure(daq):
     default args.
     We expect neglecting to provide both events and duration to raise an error.
     """
+    logger.debug('test_configure')
     assert not daq.connected
     assert not daq.configured
     daq.configure(events=1000)
@@ -101,6 +107,7 @@ def test_run_flow(daq):
     We expect that wait will block the thread until the daq is no longer
     running
     """
+    logger.debug('test_run_flow')
     with pytest.raises(RuntimeError):
         daq.begin()
     assert daq.state == 'Disconnected'
@@ -148,6 +155,7 @@ def test_scan(daq):
     """
     We expect that the daq object is usable in a bluesky plan.
     """
+    logger.debug('test_scan')
     RE = RunEngine({})
     daq.connect()
     daq.configure(duration=60, record=False)

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -84,6 +84,7 @@ def test_configure(daq):
         daq.configure()
 
 
+@pytest.mark.timeout(20)
 def test_run_flow(daq):
     """
     We expect a begin without a configure to throw an error.
@@ -134,6 +135,7 @@ def test_run_flow(daq):
     assert daq.state == 'Configured'
 
 
+@pytest.mark.timeout(10)
 def test_scan(daq):
     """
     We expect that the daq object is usable in a bluesky plan.

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -73,7 +73,7 @@ def test_configure(daq):
         dict(events=1000, use_l3t=True, record=True),
         dict(duration=10, controls=[]),
     ]
-    prev_config = dict(duration=60)
+    prev_config = daq.read_configuration()
     for config in configs:
         old, new = daq.configure(**config)
         assert old == prev_config
@@ -102,13 +102,13 @@ def test_run_flow(daq):
     assert daq.state == 'Configured'
     daq.begin()
     assert daq.state == 'Running'
-    time.sleep(1.1)
+    time.sleep(1.3)
     assert daq.state == 'Open'
     daq.begin(duration=2)
     assert daq.state == 'Running'
-    time.sleep(1.1)
+    time.sleep(1.3)
     assert daq.state == 'Running'
-    time.sleep(1.1)
+    time.sleep(1.3)
     assert daq.state == 'Open'
     daq.end_run()
     assert daq.state == 'Configured'

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -85,7 +85,7 @@ def test_configure(daq):
         assert daq.read_configuration() == new
         for key, value in config.items():
             assert new[key] == value
-        prev_config = config
+        prev_config = daq.read_configuration()
     with pytest.raises(RuntimeError):
         daq.configure()
 

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -96,42 +96,42 @@ def test_run_flow(daq):
     """
     with pytest.raises(RuntimeError):
         daq.begin()
-    assert daq.state() == 'Disconnected'
+    assert daq.state == 'Disconnected'
     daq.configure(duration=1)
-    assert daq.state() == 'Configured'
+    assert daq.state == 'Configured'
     daq.begin()
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     time.sleep(1.1)
-    assert daq.state() == 'Open'
+    assert daq.state == 'Open'
     daq.begin(duration=2)
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     time.sleep(1.1)
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     time.sleep(1.1)
-    assert daq.state() == 'Open'
+    assert daq.state == 'Open'
     daq.end_run()
-    assert daq.state() == 'Configured'
+    assert daq.state == 'Configured'
     daq.configure(duration=60)
     t0 = time.time()
     daq.begin()
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     daq.stop()
-    assert daq.state() == 'Open'
+    assert daq.state == 'Open'
     assert time.time() - t0 < 5
     t1 = time.time()
     daq.begin(duration=2)
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     daq.wait()
-    assert daq.state() == 'Open'
+    assert daq.state == 'Open'
     assert time.time() - t1 > 2
     daq.begin(duration=60)
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     daq.pause()
-    assert daq.state() == 'Open'
+    assert daq.state == 'Open'
     daq.resume()
-    assert daq.state() == 'Running'
+    assert daq.state == 'Running'
     daq.end_run()
-    assert daq.state() == 'Configured'
+    assert daq.state == 'Configured'
 
 
 def test_scan(daq):
@@ -141,17 +141,17 @@ def test_scan(daq):
     RE = RunEngine({})
     daq.connect()
     daq.configure(duration=60, record=False)
-    assert daq.status() == 'Configured'
+    assert daq.state == 'Configured'
 
     @fly_during_decorator([daq])
     @stage_decorator([daq])
     @run_decorator()
     def plan(reader):
         for i in range(10):
-            assert daq.status() == 'Running'
+            assert daq.state == 'Running'
             yield from trigger_and_read([reader])
-        assert daq.status() == 'Running'
+        assert daq.state == 'Running'
 
     RE(plan(Reader('test', {'zero': lambda: 0})))
 
-    assert daq.status() == 'Configured'
+    assert daq.state == 'Configured'

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -178,8 +178,9 @@ def test_pause_resume(daq):
     daq.resume()
     assert daq.state == 'Running'
     daq.stop()
-    assert daq.state == 'Configure'
+    assert daq.state == 'Open'
     daq.end_run()
+    assert daq.state == 'Configured'
 
 
 @pytest.mark.skipif(not has_bluesky, reason='Requires Bluesky')

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -4,10 +4,14 @@ import time
 import logging
 import pytest
 
-from bluesky import RunEngine
-from bluesky.examples import Reader
-from bluesky.plans import (fly_during_decorator, stage_decorator,
-                           run_decorator, trigger_and_read)
+try:
+    from bluesky import RunEngine
+    from bluesky.examples import Reader
+    from bluesky.plans import (fly_during_decorator, stage_decorator,
+                               run_decorator, trigger_and_read)
+    has_bluesky = True
+except:
+    has_bluesky = False
 
 from pcdsdevices.daq import Daq
 from pcdsdevices.sim.daq import SimDaq
@@ -65,7 +69,7 @@ def test_configure(daq):
     assert not daq.configured
     daq.configure(events=1000)
     assert daq.read_configuration()['events'] == 1000
-    assert daq.read_configuration()['duration'] == None
+    assert daq.read_configuration()['duration'] is None
     assert daq.connected
     assert daq.configured
     daq.disconnect()
@@ -75,7 +79,7 @@ def test_configure(daq):
     assert daq.connected
     assert not daq.configured
     daq.configure(duration=60)
-    assert daq.read_configuration()['events'] == None
+    assert daq.read_configuration()['events'] is None
     assert daq.read_configuration()['duration'] == 60
     assert daq.connected
     assert daq.configured
@@ -150,6 +154,7 @@ def test_run_flow(daq):
     assert daq.state == 'Configured'
 
 
+@pytest.mark.skipif(not has_bluesky, reason='Requires Bluesky')
 @pytest.mark.timeout(10)
 def test_scan(daq):
     """


### PR DESCRIPTION
Configure and run the daq via pydaq, now in a Flyer object. This has been tested on the real pydaq (requires a full daq to test) and has unit tests with a simulated pydaq. This was requested by Diling for Split and Delay.

Also attached to this PR:
- Added bluesky to the testing environment because I needed to check if the Flyer worked
- Added a logging config to the run_tests.py file to help me debug. This creates a new log file for each test run and saves the most recent 10.