### PR TITLE
ENH: MPS Factory

### DIFF
--- a/pcdsdevices/epics/__init__.py
+++ b/pcdsdevices/epics/__init__.py
@@ -7,7 +7,7 @@ from .valve import PPSStopper, Stopper, GateValve, InterlockError
 from .attenuator import FeeAtt, Attenuator
 from .ipm import IPM
 from .pim import PIM, PIMMotor, PIMPulnixDetector, PIMFee
-from .mirror import OffsetMirror
+from .mirror import PointingMirror, OffsetMirror
 from .mps import MPS
 from .lodcm import LODCM
 from .movablestand import MovableStand

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -960,7 +960,7 @@ class OffsetMirror(Device, PositionerBase):
 
 class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     """
-    mps : str, optional
+    mps_prefix : str, optional
         Base prefix for the MPS bit of the mirror
 
     state_prefix : str, optional
@@ -978,10 +978,10 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     #State Information
     state = FormattedComponent(InOutStates, '{self._state_prefix}')
     
-    def __init__(self, *args, mps=None, state_prefix=None, out_lines=None,
+    def __init__(self, *args, mps_prefix=None, state_prefix=None, out_lines=None,
                  in_lines=None, **kwargs):
         #Store MPS information
-        self._mps_prefix = mps
+        self._mps_prefix = mps_prefix
         #Store State information
         self._state_prefix = state_prefix 
         #Branching pattern

--- a/pcdsdevices/epics/mps.py
+++ b/pcdsdevices/epics/mps.py
@@ -18,7 +18,7 @@ from ..interface import MPSInterface
 ##########
 from ophyd      import Device
 from .signal    import EpicsSignal, EpicsSignalRO
-from .component import Component as C
+from .component import Component as C, FormattedComponent as FC
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class MPS(Device, metaclass=MPSInterface):
     """
     Class to interpret MPS information
-  
+
     The intention of this class is to be used as a sub-component of a device.
     There are three major attributes of each MPS bit that are relevant to
     operations; :attr:`.faulted` , :attr:`.bypassed` and :attr:`.veto_capable`.
@@ -101,3 +101,36 @@ class MPS(Device, metaclass=MPSInterface):
         """
         kwargs.pop('sub_type', None)
         self._run_subs(sub_type=self.SUB_FAULT_CH, **kwargs)
+
+
+def mps_factory(clsname, cls,  *args, mps_prefix=None, veto=False,  **kwargs):
+    """
+    Create a new object of arbitrary class capable of storing MPS information
+
+    A new class identical to the provided one is created, but with additional
+    attribute `mps` that relies upon the provided `mps_prefix`. All other
+    information is passed through to the class constructor as args and kwargs
+
+    Parameters
+    ----------
+    clsname : str
+        Name of new class to create
+
+    cls :
+        Device class to add `mps`
+
+    mps_prefix : str
+        Prefix for MPS subcomponent
+
+    veto : bool, optional
+        Whether the MPS bit is capable of veto
+
+    args :
+        Passed to device constructor
+
+    kwargs:
+        Passed to device constructor
+    """
+    comp = FC(MPS, mps_prefix, veto=veto)
+    cls  = type(clsname, (cls,), {'mps' : comp})
+    return cls(*args, **kwargs)

--- a/pcdsdevices/epics/mps.py
+++ b/pcdsdevices/epics/mps.py
@@ -103,7 +103,7 @@ class MPS(Device, metaclass=MPSInterface):
         self._run_subs(sub_type=self.SUB_FAULT_CH, **kwargs)
 
 
-def mps_factory(clsname, cls,  *args, mps_prefix=None, veto=False,  **kwargs):
+def mps_factory(clsname, cls,  *args, mps_prefix, veto=False,  **kwargs):
     """
     Create a new object of arbitrary class capable of storing MPS information
 

--- a/tests/test_epics_mirror.py
+++ b/tests/test_epics_mirror.py
@@ -17,7 +17,7 @@ from pcdsdevices.sim.pv       import using_fake_epics_pv
 @pytest.fixture(scope='function')
 def branching_mirror():
     m = PointingMirror("MIRR:TST:M1H", "GANTRY:TST:M1H",
-                     mps="MIRR:M1H:MPS", state_prefix="TST:M1H",
+                     mps_prefix="MIRR:M1H:MPS", state_prefix="TST:M1H",
                      in_lines=['MFX', 'MEC'], out_lines= ['CXI'])
     m.state.state._read_pv.enum_strs = ['IN', 'OUT']
     return m

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -1,20 +1,22 @@
 ############
 # Standard #
 ############
-import logging
 import time
+import logging
+from functools import partial
 
 ###############
 # Third Party #
 ###############
 import pytest
+from ophyd import Device
 from unittest.mock import Mock
 
 ##########
 # Module #
 ##########
 from pcdsdevices.sim.pv import using_fake_epics_pv
-from pcdsdevices.epics  import MPS
+from pcdsdevices.epics.mps import MPS, mps_factory
 
 @using_fake_epics_pv
 @pytest.fixture(scope='function')
@@ -42,4 +44,18 @@ def test_mps_subscriptions(mps):
     mps.fault._read_pv.put(1)
     assert cb.called
 
-
+@using_fake_epics_pv
+def test_mps_factory():
+    #Create a custom device
+    class MyDevice(Device):
+        pass
+    #Create a constructor for the MPS version of that device
+    MPSDevice = partial(mps_factory, 'MPSDevice', MyDevice)
+    #Create an instanace of the MPSDevice
+    d = MPSDevice('Tst:Prefix', name='Tst', mps_prefix='Tst:Mps:Prefix')
+    #Check we made an MPS subcomponent
+    assert hasattr(d, 'mps')
+    assert isinstance(d.mps, MPS)
+    assert d.mps.prefix == 'Tst:Mps:Prefix'
+    #Check our original device constructor still worked
+    assert d.name == 'Tst'


### PR DESCRIPTION
First time with the factory stuff so please let me know if this makes sense. Made a function called `mps_factory` that takes a regular pcdsdevices class, keywords -> `mps_prefix`, `veto`, `args` and `kwargs`. The function then creates a new instance of the class with a subcomponent `mps`, and passes args and kwargs to the device constructor. The idea is you can make an arbitrary mps device constructor from another class using this and `functools.partial`:

```python
MPSDevice = partial(mps_factory, 'MPSDevice', Device)
d = MPSDevice(prefix='Tst:Prefix', mps_prefix='Tst:Mps:Prefix')
```
**Also**
---
* I made `mps` versions of `Stopper` and` GateValve`. I left `PointingMirror` and `PPSStopper` with explicit `mps` components as these will always have MPS inputs
*  I changed the API so the `mps_prefix` kwarg is consistent throughout the devices. `mps` seemed too short and vague , so I unified behind the standard`mps_prefix`. This meant breaking API for the `PPSStopper` and `PointingMirror`