### PR TITLE
MAINT: Devices Odds and Ends

### DIFF
--- a/pcdsdevices/epics/__init__.py
+++ b/pcdsdevices/epics/__init__.py
@@ -5,7 +5,7 @@ from .pulsepicker import PickerBlade, PulsePicker, PulsePickerCCM, PulsePickerPi
 from .slits import Slits
 from .valve import PPSStopper, Stopper, GateValve, InterlockError
 from .attenuator import FeeAtt, Attenuator
-from .ipm import IPM
+from .ipm import IPM, IPMMotors
 from .pim import PIM, PIMMotor, PIMPulnixDetector, PIMFee
 from .mirror import PointingMirror, OffsetMirror
 from .mps import MPS

--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -490,7 +490,9 @@ class AttenuatorBase(BasicAttenuatorBase):
 
     def __init__(self, prefix, *, name=None, read_attrs=None,
                  stage_setting=0, **kwargs):
-        self._filter_prefix = prefix.rstrip(':COM')
+        #Modify prefixes
+        self._filter_prefix = prefix
+        prefix += ':COM'
         if read_attrs is None:
             read_attrs = ["transmission", "transmission_3rd"]
         super().__init__(prefix, name=name, read_attrs=read_attrs,

--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -490,8 +490,7 @@ class AttenuatorBase(BasicAttenuatorBase):
 
     def __init__(self, prefix, *, name=None, read_attrs=None,
                  stage_setting=0, **kwargs):
-        prefix = prefix + ":ATT:COM"
-        self._filter_prefix = prefix + ":ATT"
+        self._filter_prefix = prefix.rstrip(':COM')
         if read_attrs is None:
             read_attrs = ["transmission", "transmission_3rd"]
         super().__init__(prefix, name=name, read_attrs=read_attrs,

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -10,28 +10,22 @@ from ophyd.status import wait as status_wait
 TargetStates = statesrecord_class("TargetStates", ":OUT", ":TARGET1",
                                   ":TARGET2", ":TARGET3", ":TARGET4")
 
-
-class IPM(Device):
+class IPMMotors(Device):
     """
-    Standard intensity position monitor. Consists of two stages, one for the
-    diode and one for the target. This creates a scalar readback that is also
-    available over EPICS.
+    Standard intensity position monitor motion.
     """
     diode = Component(InOutStates,   ":DIODE")
     target = Component(TargetStates, ":TARGET")
-    data = FormattedComponent(EpicsSignalRO, "{self._data}")
 
     #Default subscriptions
     SUB_ST_CHG   = 'target_state_changed'
     _default_sub = SUB_ST_CHG
     transmission = 0.8 #Completely making up this number :)
 
-    def __init__(self, prefix, *, data="", name=None, parent=None,
+    def __init__(self, prefix, *, name=None, parent=None,
                  read_attrs=None, **kwargs):
-        #Default read attributes
-        self._data = data
         if read_attrs is None:
-            read_attrs = ["data"]
+            read_attrs = ["diode", "target"]
 
         super().__init__(prefix, name=name, parent=parent,
                          read_attrs=read_attrs, **kwargs)
@@ -129,3 +123,20 @@ class IPM(Device):
         kwargs.pop('sub_type', None)
         #Run subscriptions
         self._run_subs(sub_type=self.SUB_ST_CHG, **kwargs)
+
+
+class IPM(Device):
+    """
+    Class for standard Intensity Monitors
+    """
+    motors = Component(IPMMotors, '')
+    data   = Component(EpicsSignalRO, '{self._data}')
+
+    def __init__(self, prefix, data,  *, name=None, parent=None,
+                 read_attrs=None, **kwargs):
+        self._data = data
+        #Default read attributes
+        if not read_attrs:
+            read_attrs = ['data']
+        super().__init__(prefix, name=name, parent=parent,
+                         read_attrs=read_attrs, **kwargs)

--- a/pcdsdevices/epics/pulsepicker.py
+++ b/pcdsdevices/epics/pulsepicker.py
@@ -12,8 +12,8 @@ class PickerBlade(Device):
     """
     Represent the pulse picker blade as separte device
     """
-    simple_state = Component(EpicsSignalRO, "DF")
-    force_close  = Component(EpicsSignal,   "S_CLOSE")
+    simple_state = Component(EpicsSignalRO, ":DF")
+    force_close  = Component(EpicsSignal,   ":S_CLOSE")
     #Subscription information
     SUB_ST_CH = 'sub_state_changed'
     _default_sub = SUB_ST_CH

--- a/tests/test_epics_ipm.py
+++ b/tests/test_epics_ipm.py
@@ -12,14 +12,14 @@ from unittest.mock import Mock
 # Module #
 ##########
 from pcdsdevices.sim.pv import  using_fake_epics_pv
-from pcdsdevices.epics import IPM
+from pcdsdevices.epics import IPMMotors
 
 logger = logging.getLogger(__name__)
 
 @using_fake_epics_pv
 @pytest.fixture(scope='function')
 def ipm():
-    return IPM("Test:My:IPM")
+    return IPMMotors("Test:My:IPM")
 
 
 @using_fake_epics_pv


### PR DESCRIPTION
* Created an IPMMotors class. This is all the lightpath should need, the full IPM with option for `data` key still exists with IPMMotors as a subclass
* I changed the Attenuator prefix handling.  Having just prefix `XPP` or `MFX` in the `happi` config seems like a bad idea, so you must now specify `MFX:ATT:COM`. I also fixed it so that the filter_prefix was being instantiated correctly, as it was not previously
* PickerBlade had no leading `:` for the signal specifications