### PR TITLE
ENH: XFLS Class

### DIFF
--- a/pcdsdevices/epics/__init__.py
+++ b/pcdsdevices/epics/__init__.py
@@ -6,6 +6,8 @@ from .slits import Slits
 from .valve import PPSStopper, Stopper, GateValve, InterlockError
 from .attenuator import FeeAtt, Attenuator
 from .ipm import IPM, IPMMotors
+from .lens import XFLS
+from .ipm import IPM
 from .pim import PIM, PIMMotor, PIMPulnixDetector, PIMFee
 from .mirror import PointingMirror, OffsetMirror
 from .mps import MPS

--- a/pcdsdevices/epics/lens.py
+++ b/pcdsdevices/epics/lens.py
@@ -1,0 +1,90 @@
+"""
+Basic Beryllium Lens XFLS
+"""
+############
+# Standard #
+############
+
+###############
+# Third Party #
+###############
+from ophyd import Component as C
+from ophyd.status import wait as status_wait
+
+##########
+# Module #
+##########
+from .device import Device
+from .signal import EpicsSignal
+from .state  import SubscriptionStatus
+
+class XFLS(Device):
+    """
+    XFLS Device
+
+    The XFLS device has flexibility on what the state names are ultimately
+    called, therefore this class simply interpets the base signal without
+    providing the ability to check each individual state
+    """
+    state = C(EpicsSignal,'', write_pv=':GO')
+    SUB_ST_CH = 'sub_state_changed'
+    _default_sub = SUB_ST_CH
+
+    @property
+    def inserted(self):
+        """
+        Whether the lens is considered in
+        """
+        return self.state.value in list(range(1,4))
+
+    @property
+    def removed(self):
+        """
+        Whether the lens is removed
+        """
+        return self.state.value == 4
+
+    def remove(self, wait=False, timeout=None, **kwargs):
+        """
+        Remove XFLS from the beamline
+
+        Parameters
+        ----------
+        wait : bool
+
+        timeout : float, optional
+            Default timeout to wait mark the request as a failure
+
+        Returns
+        -------
+        SubscriptionStatus:
+            Future that reports the completion of the request
+        """
+        #Place command
+        self.state.put(4)
+        def cb():
+            return self.state.value == 4
+        status = SubscriptionStatus(self.state, cb, timeout=timeout)
+        #Optional wait
+        if wait:
+            status_wait(status)
+        return status
+
+    def subscribe(self, cb, event_type=None, run=False):
+        """
+        Subscribe to changes in the XFLS state
+
+        This simply maps to the :attr:`.state` component
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        return self.state.subscribe(cb, event_type=event_type, run=run)

--- a/pcdsdevices/epics/mps.py
+++ b/pcdsdevices/epics/mps.py
@@ -61,7 +61,7 @@ class MPS(Device, metaclass=MPSInterface):
         self._veto = veto
         #Default read attributes
         if read_attrs is None:
-            read_attrs = ['faulted', 'tripped']
+            read_attrs = ['fault', 'bypass']
         #Device initialization
         super().__init__(prefix, name=name, read_attrs=read_attrs, **kwargs)
         #Subscribe state change callback

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -7,7 +7,7 @@ import logging
 from enum import Enum
 from copy import deepcopy
 from functools import partial
-
+from ophyd.status import wait as status_wait
 from .mps import MPS, mps_factory
 from .state import pvstate_class, StateStatus
 from .device import Device

--- a/tests/test_epics_lens.py
+++ b/tests/test_epics_lens.py
@@ -1,0 +1,51 @@
+############
+# Standard #
+############
+from unittest.mock import Mock
+
+###############
+# Third Party #
+###############
+import pytest
+
+##########
+# Module #
+##########
+from pcdsdevices.sim.pv import using_fake_epics_pv
+from pcdsdevices.epics  import XFLS
+
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def xfls():
+    return XFLS("TST:XFLS")
+
+
+@using_fake_epics_pv
+def test_xfls_states(xfls):
+    #Remove
+    xfls.state._read_pv.put(4)
+    assert xfls.removed
+    assert not xfls.inserted
+    #Insert
+    xfls.state._read_pv.put(3)
+    assert not xfls.removed
+    assert xfls.inserted
+    #Unknown
+    xfls.state._read_pv.put(0)
+    assert not xfls.removed
+    assert not xfls.inserted
+
+@using_fake_epics_pv
+def test_xfls_motion(xfls):
+    xfls.remove()
+    assert xfls.state._write_pv.get() == 4
+
+@using_fake_epics_pv
+def test_xfls_subscriptions(xfls):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    xfls.subscribe(cb, run=False)
+    #Change readback state
+    xfls.state._read_pv.put(4)
+    assert cb.called


### PR DESCRIPTION
Add XFLS class for Berylium Lenses. This class was trickier than first imagined as the `ims` class gives a lot of flexibility to what you name the states of your IOC (in CXI/MFX we name them on the energy that they will most likely be used at). Unfortunately this means I couldn't use the `statesrecord_class`  constructor out of the box. Long term we should probably standardize these IOCs or make a factory of some sort. For now, I opted for the lazy solution of just reading the main mbbi and if the state is not `removed` or `unknown` I assume it is inserted. Kind of a lazy method, but I don't really want to spend time on this until we have a more advanced use case. This is good enough for the lightpath.

@ZLLentz am I being lazy or efficient? Can't tell these days ...

Also, some minor bug fixes:

* Missed a `status_wait` import in `pcdsdevices.epics.valve` guess `wait` never gets called in the tests
* The `MPS` component had default read_attrs that linked to properties. I switched this to read the signals, if we really want to read the interpreted state we can use `AttributeSignal` but did not seem necessary for now.