### PR TITLE
FIX: Misc LODCM

### DIFF
--- a/pcdsdevices/epics/lodcm.py
+++ b/pcdsdevices/epics/lodcm.py
@@ -16,8 +16,7 @@ YagLomStates = statesrecord_class("YagLomStates", ":OUT", ":YAG", ":SLIT1",
                                   ":SLIT2", ":SLIT3")
 DectrisStates = statesrecord_class("DectrisStates", ":OUT", ":DECTRIS",
                                    ":SLIT1", ":SLIT2", ":SLIT3", ":OUTLOW")
-FoilStates = statesrecord_class("FoilStates", ":OUT", ":Mo", ":Zr", ":Zn",
-                                ":Cu", ":Ni", ":Fe", "Ti")
+FoilStates = statesrecord_class("FoilStates", ":OUT")
 
 
 class LODCM(Device, metaclass=BranchingInterface):

--- a/pcdsdevices/epics/lodcm.py
+++ b/pcdsdevices/epics/lodcm.py
@@ -10,7 +10,8 @@ from .state import statesrecord_class, InOutStates
 from .component import Component
 
 
-LodcmStates = statesrecord_class("LodcmStates", ":OUT", ":C", ":Si")
+H1NStates = statesrecord_class("LodcmStates", ":OUT", ":C", ":Si")
+H2NStates = statesrecord_class("LodcmStates", ":C", ":Si")
 YagLomStates = statesrecord_class("YagLomStates", ":OUT", ":YAG", ":SLIT1",
                                   ":SLIT2", ":SLIT3")
 DectrisStates = statesrecord_class("DectrisStates", ":OUT", ":DECTRIS",
@@ -28,8 +29,8 @@ class LODCM(Device, metaclass=BranchingInterface):
     diagnostic devices between them. Beam can continue onto the main line, onto
     the mono line, onto both, or onto neither.
     """
-    h1n = Component(LodcmStates, ":H1N")
-    h2n = Component(LodcmStates, ":H2N")
+    h1n = Component(H1NStates, ":H1N")
+    h2n = Component(H2NStates, ":H2N")
     yag = Component(YagLomStates, ":DV")
     dectris = Component(DectrisStates, ":DH")
     diode = Component(InOutStates, ":DIODE")
@@ -64,14 +65,15 @@ class LODCM(Device, metaclass=BranchingInterface):
             self.main_line if the light continues on the main line.
             self.mono_line if the light continues on the mono line.
         """
-        # H2N:     OUT      C       Si    Unknown
-        table = [["MAIN", "MAIN", "MAIN", "MAIN"],              # H1N at OUT
-                 ["MAIN", "BOTH", "MAIN", "BLOCKED"],           # H1N at C
-                 ["BLOCKED", "BLOCKED", "MONO", "BLOCKED"],     # H1N at Si
-                 ["BLOCKED", "BLOCKED", "BLOCKED", "BLOCKED"]]  # H1N Unknown
-        states = ("OUT", "C", "Si", "Unknown")
-        n1 = states.index(self.h1n.value)
-        n2 = states.index(self.h2n.value)
+        # H2N:      C       Si    Unknown
+        table = [["MAIN", "MAIN", "MAIN"],           # H1N at OUT
+                 ["BOTH", "MAIN", "BLOCKED"],        # H1N at C
+                 ["BLOCKED", "MONO", "BLOCKED"],     # H1N at Si
+                 ["BLOCKED", "BLOCKED", "BLOCKED"]]  # H1N Unknown
+        h1n_states = ("OUT", "C", "Si", "Unknown")
+        h2n_states = ("C", "Si", "Unknown")
+        n1 = h1n_states.index(self.h1n.value)
+        n2 = h2n_states.index(self.h2n.value)
         state = table[n1][n2]
         if state == "MAIN":
             return [self.main_line]

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -13,19 +13,19 @@ def lodcm():
     lom = LODCM('FAKE:LOM', name='fake_lom', main_line='MAIN')
     lom.h1n.state._read_pv.put('OUT')
     lom.h1n.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
-    lom.h2n.state._read_pv.put('OUT')
-    lom.h2n.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
+    lom.h2n.state._read_pv.put('C')
+    lom.h2n.state._read_pv.enum_strs = ['C', 'Si']
     lom.yag.state._read_pv.put('OUT')
     lom.yag.state._read_pv.enum_strs = ['OUT', 'YAG', 'SLIT1', 'SLIT2',
-                                              'SLIT3']
+                                        'SLIT3']
     lom.dectris.state._read_pv.put('OUT')
     lom.dectris.state._read_pv.enum_strs = ['OUT', 'DECTRIS', 'SLIT1',
-                                                  'SLIT2', 'SLIT3', 'OUTLOW']
+                                            'SLIT2', 'SLIT3', 'OUTLOW']
     lom.diode.state._read_pv.put('OUT')
     lom.diode.state._read_pv.enum_strs = ['OUT', 'IN']
     lom.foil.state._read_pv.put('OUT')
     lom.foil.state._read_pv.enum_strs = ['OUT', 'Mo', 'Zr', 'Zn', 'Cu',
-                                               'Ni', 'Fe', 'Ti']
+                                         'Ni', 'Fe', 'Ti']
     return lom
 
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -24,8 +24,7 @@ def lodcm():
     lom.diode.state._read_pv.put('OUT')
     lom.diode.state._read_pv.enum_strs = ['OUT', 'IN']
     lom.foil.state._read_pv.put('OUT')
-    lom.foil.state._read_pv.enum_strs = ['OUT', 'Mo', 'Zr', 'Zn', 'Cu',
-                                         'Ni', 'Fe', 'Ti']
+    lom.foil.state._read_pv.enum_strs = ['OUT']
     return lom
 
 

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -11,20 +11,20 @@ from pcdsdevices.epics.lodcm import LODCM
 @using_fake_epics_pv
 def lodcm():
     lom = LODCM('FAKE:LOM', name='fake_lom', main_line='MAIN')
-    lom.h1n_state.state._read_pv.put('OUT')
-    lom.h1n_state.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
-    lom.h2n_state.state._read_pv.put('OUT')
-    lom.h2n_state.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
-    lom.yag_state.state._read_pv.put('OUT')
-    lom.yag_state.state._read_pv.enum_strs = ['OUT', 'YAG', 'SLIT1', 'SLIT2',
+    lom.h1n.state._read_pv.put('OUT')
+    lom.h1n.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
+    lom.h2n.state._read_pv.put('OUT')
+    lom.h2n.state._read_pv.enum_strs = ['OUT', 'C', 'Si']
+    lom.yag.state._read_pv.put('OUT')
+    lom.yag.state._read_pv.enum_strs = ['OUT', 'YAG', 'SLIT1', 'SLIT2',
                                               'SLIT3']
-    lom.dectris_state.state._read_pv.put('OUT')
-    lom.dectris_state.state._read_pv.enum_strs = ['OUT', 'DECTRIS', 'SLIT1',
+    lom.dectris.state._read_pv.put('OUT')
+    lom.dectris.state._read_pv.enum_strs = ['OUT', 'DECTRIS', 'SLIT1',
                                                   'SLIT2', 'SLIT3', 'OUTLOW']
-    lom.diode_state.state._read_pv.put('OUT')
-    lom.diode_state.state._read_pv.enum_strs = ['OUT', 'IN']
-    lom.foil_state.state._read_pv.put('OUT')
-    lom.foil_state.state._read_pv.enum_strs = ['OUT', 'Mo', 'Zr', 'Zn', 'Cu',
+    lom.diode.state._read_pv.put('OUT')
+    lom.diode.state._read_pv.enum_strs = ['OUT', 'IN']
+    lom.foil.state._read_pv.put('OUT')
+    lom.foil.state._read_pv.enum_strs = ['OUT', 'Mo', 'Zr', 'Zn', 'Cu',
                                                'Ni', 'Fe', 'Ti']
     return lom
 
@@ -69,5 +69,5 @@ def test_subscribe(lodcm):
     lodcm.subscribe(cb, run=False)
     assert not cb.called
     # Change destination from main to mono
-    lodcm.h1n_state.state._read_pv.put('C')
+    lodcm.h1n.state._read_pv.put('C')
     assert cb.called


### PR DESCRIPTION
- Handle Unknown states in destinations, treat as blocking.
- Allow instantiation without happi db if we don't pass a main_line.
- Clean up some attribute names.
- H2N doesn't have an OUT state
- The LODCMs have slightly different foil PVs for different materials. I'm removing all of these from the states for now, because they aren't relevant for lightpath.