### PR TITLE
ENH: Add raw input value to states

### DIFF
--- a/pcdsdevices/epics/state.py
+++ b/pcdsdevices/epics/state.py
@@ -267,6 +267,7 @@ def statesrecord_class(classname, *states, doc=""):
     for state_name in states:
         name = state_name.lower().replace(":", "") + "_state"
         components[name] = Component(DeviceStatesPart, state_name)
+    components['raw'] = Component(EpicsSignalRO, states[0] + "_CALC.A")
     bases = (DeviceStatesRecord,)
     return type(classname, bases, components)
 


### PR DESCRIPTION
Pull the raw source value into factory-created states classes. This can be compared against the setpoints to diagnose an Unknown state. It works by checking the CALC record value being used to output a state string.

I made this addition because all the LODCM states are out of whack and I didn't have a quick way to see why. This makes it very easy to check the raw position from an instantiated states object and may be useful for other devices.