### PR TITLE
ENH: DAQ Calibcycles

### DIFF
--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -114,7 +114,10 @@ class SimControl:
                 else:
                     return ev / 120
             if duration is not None:
-                return duration
+                if isinstance(duration, list):
+                    return duration[0] + duration[1]*10e-9
+                else:
+                    return duration
             return None
 
     def stop(self):


### PR DESCRIPTION
Between 'create' and 'save' documents, the daq will run. There is an option to use original run-forever features. The 'controls' argument has been reworked to be very similar to the good parts of old python.

Misc bugfixes in cleanup, using correct syntax now instead of bad confluence API docs. Added a bunch of debug statements.