### PR TITLE
FIX: Testing robustness and edge cases

### DIFF
--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -540,6 +540,8 @@ class Daq(FlyerInterface):
             self._is_bluesky = False
         if not config['always_on']:
             if msg.command == 'create':
+                # If already runing, pause first to start a fresh begin
+                self.pause()
                 self.resume()
             elif msg.command == 'save':
                 do_wait = False

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -231,7 +231,6 @@ def test_run_flow(daq):
     def plan(reader):
         yield from null()
         for i in range(10):
-            assert daq.state == 'Open'
             yield from create()
             assert daq.state == 'Running'
             yield from read(reader)
@@ -263,7 +262,6 @@ def test_run_flow_wait(daq):
     def plan(reader):
         yield from null()
         for i in range(10):
-            assert daq.state == 'Open'
             yield from create()
             assert daq.state == 'Running'
             yield from read(reader)


### PR DESCRIPTION
Changed sim daq to fail in the new ways we discovered from real daq
Remove unnecessary checks from the calibcycle tests
Cover edge case where first calibcycle could fail if starts too soon