### PR TITLE
API: Light subscriptions

### DIFF
--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -445,6 +445,7 @@ class BasicAttenuatorBase(Device):
             #Subscribe to all child filter objects
             for filt in self.filters:
                 filt.state_sig.subscribe(self._blade_moved, run=False)
+            self._has_subscribed = True
         super().subscribe(cb, event_type=event_type, run=run)
 
 

--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -150,8 +150,8 @@ class BasicAttenuatorBase(Device):
     go_cmd = Component(EpicsSignal, ":GO")
 
     #Subscription Information
-    SUB_BLADE_CH = 'sub_blade_changed'
-    _default_sub = SUB_BLADE_CH
+    SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, name=None, read_attrs=None,
                  stage_setting=0, **kwargs):
@@ -165,6 +165,7 @@ class BasicAttenuatorBase(Device):
         #Subscribe to all child filter objects
         for filt in self.filters:
             filt.state_sig.subscribe(self._blade_moved, run=False)
+
 
     def __call__(self, transmission=None, **kwargs):
         """
@@ -220,7 +221,7 @@ class BasicAttenuatorBase(Device):
         #Create status that will mark done when all are moved
         status = SubscriptionStatus(self,
                                     lambda *args, **kwargs: self.inserted,
-                                    event_type = self.SUB_BLADE_CH,
+                                    event_type = self.SUB_STATE,
                                     timeout=timeout)
         #Optionally wait for status
         if wait:
@@ -239,7 +240,7 @@ class BasicAttenuatorBase(Device):
         #Create status that will mark done when all are moved
         status = SubscriptionStatus(self,
                                     lambda *args, **kwargs: self.removed,
-                                    event_type = self.SUB_BLADE_CH,
+                                    event_type = self.SUB_STATE,
                                     timeout=timeout)
         #Optionally wait for status
         if wait:
@@ -432,8 +433,7 @@ class BasicAttenuatorBase(Device):
         Blade has moved
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_BLADE_CH, **kwargs)
-
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
 
     def stage(self):
         self.all_in()
@@ -465,10 +465,6 @@ class AttenuatorBase(BasicAttenuatorBase):
     calculations. This is the IOC running everywhere except the FEE. This base
     class does not include any filters.
     """
-    #Filter changed subscriptions
-    SUB_FILT_CH  = 'sub_filter_changed'
-    _default_sub = SUB_FILT_CH
-
     # Redefine some PV names
     energy = Component(EpicsSignalRO, ":T_CALC.VALE")
     desired_transmission = Component(EpicsSignal, ":R_DES")
@@ -497,15 +493,18 @@ class AttenuatorBase(BasicAttenuatorBase):
             read_attrs = ["transmission", "transmission_3rd"]
         super().__init__(prefix, name=name, read_attrs=read_attrs,
                          stage_setting=stage_setting, **kwargs)
-    
+
+        #If we did not receive a filter number from factory
+        if not hasattr(self, 'number_of_filters'):
+            self.number_of_filters = 0
+
     @property
     def filters(self):
         """
         List of filter components
         """
         return [getattr(self, "filter{}".format(i))
-                for i in range(1, self.num_att.value)]
-
+                for i in range(1, self.number_of_filters + 1)]
 
     def thickest_filter_in(self):
         """
@@ -559,6 +558,8 @@ def make_att_classes(max_filters):
 
         name = "Attenuator{}".format(i)
         cls = type(name, (AttenuatorBase,), att_filters)
+        #Store the number of filters
+        cls.number_of_filters = i
         globals()[name] = cls
         att_classes[i] = cls
     return att_classes

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -24,15 +24,12 @@ class IPMMotors(Device):
 
     def __init__(self, prefix, *, name=None, parent=None,
                  read_attrs=None, **kwargs):
+        self._has_subscribed = False
         if read_attrs is None:
             read_attrs = ["diode", "target"]
 
         super().__init__(prefix, name=name, parent=parent,
                          read_attrs=read_attrs, **kwargs)
-        #Subscribe to state changes
-        self.target.subscribe(self._target_moved,
-                              event_type=self.target.SUB_RBK_CHG,
-                              run=False)
 
 
     def target_in(self, target):
@@ -114,6 +111,29 @@ class IPMMotors(Device):
         """
         self.diode.value = "OUT"
 
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the ipm
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to state changes
+            self.target.subscribe(self._target_moved,
+                                  event_type=self.target.SUB_RBK_CHG,
+                                  run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _target_moved(self, **kwargs):
         """

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -18,8 +18,8 @@ class IPMMotors(Device):
     target = Component(TargetStates, ":TARGET")
 
     #Default subscriptions
-    SUB_ST_CHG   = 'target_state_changed'
-    _default_sub = SUB_ST_CHG
+    SUB_STATE   = 'target_state_changed'
+    _default_sub = SUB_STATE
     transmission = 0.8 #Completely making up this number :)
 
     def __init__(self, prefix, *, name=None, parent=None,
@@ -122,7 +122,7 @@ class IPMMotors(Device):
         #Avoid duplicate keywords
         kwargs.pop('sub_type', None)
         #Run subscriptions
-        self._run_subs(sub_type=self.SUB_ST_CHG, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
 
 
 class IPM(Device):

--- a/pcdsdevices/epics/lens.py
+++ b/pcdsdevices/epics/lens.py
@@ -32,14 +32,12 @@ class XFLS(Device):
 
     def __init__(self, prefix, *, name=None, parent=None,
                  read_attrs=None, **kwargs):
+        self._has_subscribed = False
         if read_attrs is None:
             read_attrs = ["state"]
 
         super().__init__(prefix, name=name, parent=parent,
                          read_attrs=read_attrs, **kwargs)
-        #Subscribe to state changes
-        self.state.subscribe(self._on_state_change,
-                             run=False)
     @property
     def inserted(self):
         """
@@ -79,6 +77,27 @@ class XFLS(Device):
         if wait:
             status_wait(status)
         return status
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the lenses
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to state changes
+            self.state.subscribe(self._on_state_change, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _on_state_change(self,  **kwargs):
         """

--- a/pcdsdevices/epics/lodcm.py
+++ b/pcdsdevices/epics/lodcm.py
@@ -33,8 +33,8 @@ class LODCM(Device, metaclass=BranchingInterface):
     diode = Component(InOutStates, ":DIODE")
     foil = Component(FoilStates, ":FOIL")
 
-    SUB_DST_CH = 'sub_destination_changed'
-    _default_sub = SUB_DST_CH
+    SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, name, main_line=None, mono_line='MONO',
                  **kwargs):
@@ -110,13 +110,13 @@ class LODCM(Device, metaclass=BranchingInterface):
     def _subs_update_destination(self, *args, **kwargs):
         """
         To be run whenever any of the component states changes.
-        If the destination has changed, run all SUB_DST_CH subs.
+        If the destination has changed, run all SUB_STATE subs.
         """
         new_dest = self.destination
         with self._update_dest_lock:
             if new_dest != self._last_dest:
                 self._last_dest = new_dest
-                self._run_subs(sub_type=self.SUB_DST_CH)
+                self._run_subs(sub_type=self.SUB_STATE)
 
     @property
     def branches(self):

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -977,7 +977,9 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     mps = FormattedComponent(MPS, '{self._mps_prefix}', veto=True)
     #State Information
     state = FormattedComponent(InOutStates, '{self._state_prefix}')
-    
+
+    SUB_STATE = 'sub_state_changed'
+
     def __init__(self, *args, mps_prefix=None, state_prefix=None, out_lines=None,
                  in_lines=None, **kwargs):
         #Store MPS information
@@ -988,6 +990,8 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         self.in_lines = in_lines
         self.out_lines = out_lines
         super().__init__(*args, **kwargs)
+        #Subscribe to changes in state
+        self.state.subscribe(self._on_state_change, run=False)
 
     @property
     def inserted(self):
@@ -1049,3 +1053,9 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         else:
             return [self.db.beamline]
 
+    def _on_state_change(self, **kwargs):
+        """
+        Callback run on state change
+        """
+        kwargs.pop('sub_type', None)
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -982,6 +982,7 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
 
     def __init__(self, *args, mps_prefix=None, state_prefix=None, out_lines=None,
                  in_lines=None, **kwargs):
+        self._has_subscribed = False
         #Store MPS information
         self._mps_prefix = mps_prefix
         #Store State information
@@ -990,8 +991,6 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         self.in_lines = in_lines
         self.out_lines = out_lines
         super().__init__(*args, **kwargs)
-        #Subscribe to changes in state
-        self.state.subscribe(self._on_state_change, run=False)
 
     @property
     def inserted(self):
@@ -1052,6 +1051,27 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
             return self.in_lines + self.out_lines
         else:
             return [self.db.beamline]
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the mirror
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to changes in state
+            self.state.subscribe(self._on_state_change, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _on_state_change(self, **kwargs):
         """

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -220,7 +220,7 @@ class PIMMotor(Device, PositionerBase):
                          parent=parent, timeout=timeout, **kwargs)
         self.timeout = timeout
         self.stage_cache_position = None
-        self.states.subscribe(self._on_state_change, run=False)
+        self._has_subscribed = False
 
     def move_in(self, wait=False, **kwargs):
         """
@@ -390,12 +390,32 @@ class PIMMotor(Device, PositionerBase):
             self.move(self.stage_cache_position, wait=False)
         return super().unstage()
 
-    def _on_state_change(self,  **kwargs):
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the PIMMotor
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            self.states.subscribe(self._on_state_change, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
+
+    def _on_state_change(self, **kwargs):
         """
         Callback run on state change
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(*args, sub_type=self.SUB_STATE, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
 
 
 class PIM(PIMMotor):

--- a/pcdsdevices/epics/pulsepicker.py
+++ b/pcdsdevices/epics/pulsepicker.py
@@ -19,13 +19,11 @@ class PickerBlade(Device):
     _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, name=None, read_attrs=None, **kwargs):
+        self._has_subscribed = False
         #Instantiate ophyd level
         if read_attrs is None:
             read_attrs = ['simple_state']
         super().__init__(prefix, name=name, read_attrs=read_attrs, **kwargs)
-
-        #Subscribe to state changes
-        self.simple_state.subscribe(self._blade_moved, run=False)
 
     @property
     def inserted(self):
@@ -57,6 +55,27 @@ class PickerBlade(Device):
             status_wait(status)
 
         return status
+    
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the valve
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to state changes
+            self.simple_state.subscribe(self._blade_moved, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _blade_moved(self, **kwargs):
         """

--- a/pcdsdevices/epics/pulsepicker.py
+++ b/pcdsdevices/epics/pulsepicker.py
@@ -15,8 +15,8 @@ class PickerBlade(Device):
     simple_state = Component(EpicsSignalRO, ":DF")
     force_close  = Component(EpicsSignal,   ":S_CLOSE")
     #Subscription information
-    SUB_ST_CH = 'sub_state_changed'
-    _default_sub = SUB_ST_CH
+    SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, name=None, read_attrs=None, **kwargs):
         #Instantiate ophyd level
@@ -50,7 +50,7 @@ class PickerBlade(Device):
         #Create status
         status = SubscriptionStatus(self,
                                     lambda *args, **kwargs: self.removed,
-                                    event_type = self.SUB_ST_CH,
+                                    event_type = self.SUB_STATE,
                                     timeout=timeout)
         #Optionally wait for status
         if wait:
@@ -63,7 +63,7 @@ class PickerBlade(Device):
         Blade has moved
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_ST_CH, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
 
 
 class PulsePicker(Device):

--- a/pcdsdevices/epics/slits.py
+++ b/pcdsdevices/epics/slits.py
@@ -86,6 +86,7 @@ class Slits(Device):
 
     def __init__(self, prefix, *, read_attrs=None,
                  name=None, nominal_aperature=5.0, **kwargs):
+        self._has_subscribed = False
         #Nominal
         self.nominal_aperature = nominal_aperature
         #Ophyd initialization
@@ -94,12 +95,6 @@ class Slits(Device):
 
         super().__init__(prefix, read_attrs=read_attrs, name=name,
                          **kwargs)
-
-        #Subscribe to changes in aperature
-        self.xwidth.readback.subscribe(self._aperature_changed,
-                                       run=False)
-        self.ywidth.readback.subscribe(self._aperature_changed,
-                                       run=False)
 
 
     def move(self,width,wait=False,**kwargs):
@@ -236,6 +231,30 @@ class Slits(Device):
         Overlap the slits to block the beam
         """
         self.block_cmd.put(1)
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the slits
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to changes in aperature
+            self.xwidth.readback.subscribe(self._aperature_changed,
+                                           run=False)
+            self.ywidth.readback.subscribe(self._aperature_changed,
+                                           run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _aperature_changed(self, *args, **kwargs):
         """

--- a/pcdsdevices/epics/slits.py
+++ b/pcdsdevices/epics/slits.py
@@ -81,8 +81,8 @@ class Slits(Device):
     block_cmd = Component(EpicsSignal, ":BLOCK")
 
     #Subscription information
-    SUB_AP_CH = 'aperature_changed'
-    _default_sub = SUB_AP_CH
+    SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, read_attrs=None,
                  name=None, nominal_aperature=5.0, **kwargs):
@@ -244,4 +244,4 @@ class Slits(Device):
         #Avoid duplicate keywords
         kwargs.pop('sub_type', None)
         #Run subscriptions
-        self._run_subs(sub_type=self.SUB_AP_CH, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, **kwargs)

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -89,15 +89,14 @@ class Stopper(Device):
         super().__init__(prefix,
                          read_attrs=read_attrs,
                          name=name, **kwargs)
-        #Subscribe callback to limits
-        self.limits.subscribe(self._limits_changed,
-                              run=False)
+        #Track if subscribed callback to limits 
+        self._has_subscribed = False
 
 
     def open(self, wait=False, timeout=None):
         """
         Open the stopper
-        
+
         Parameters
         ----------
         wait : bool, optional
@@ -194,6 +193,27 @@ class Stopper(Device):
         return self.limits.value == 'out'
 
 
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the valve
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            self.limits.subscribe(self._limits_changed, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
+
+
     def _limits_changed(self, *args, **kwargs):
         """
         Callback when the limit state of the stopper changes
@@ -270,16 +290,6 @@ class GateValve(Stopper):
 MPSGateValve = partial(mps_factory, 'MPSGateValve', GateValve)
 MPSStopper   = partial(mps_factory, 'MPSStopper', Stopper)
 
-PPS = pvstate_class('PPS',
-                    {'signal': {'pvname': '',
-                                 0: 'out',
-                                 1: 'unknown',
-                                 2: 'unknown',
-                                 3: 'unknown',
-                                 4: 'in'}},
-                    doc='MPS Summary of Stopper state')
-
-
 class PPSStopper(Device):
     """
     PPS Stopper
@@ -295,8 +305,14 @@ class PPSStopper(Device):
 
     name : str, optional
         Alias for the stopper
+
+    in_state : str, optional
+        String associatted with in enum value
+
+    out_state :str, optional
+        String associatted with out enum value
     """
-    summary = C(PPS, '')
+    summary = C(EpicsSignalRO, '')
     SUB_STATE = 'sub_state_changed'
     _default_sub = SUB_STATE
 
@@ -304,9 +320,11 @@ class PPSStopper(Device):
     mps = FC(MPS, '{self._mps_prefix}', veto=True)
 
     def __init__(self, prefix, *, name=None,
-                 read_attrs=None,
-                 mps_prefix=None, **kwargs):
-
+                 read_attrs=None, in_state='IN',
+                 out_state='OUT', mps_prefix=None, **kwargs):
+        #Store state information
+        self.in_state, self.out_state = in_state, out_state 
+        self._has_subscribed = False
         #Store MPS information
         self._mps_prefix = mps_prefix
 
@@ -316,15 +334,13 @@ class PPSStopper(Device):
         super().__init__(prefix,
                          read_attrs=read_attrs,
                          name=name, **kwargs)
-        #Subscribe to state changes
-        self.summary.subscribe(self._on_state_change, run=False)
 
     @property
     def inserted(self):
         """
         Inserted limit of PPS stopper
         """
-        return self.summary.value == 'in'
+        return self.summary.get(as_string=True) == self.in_state
 
 
     @property
@@ -332,7 +348,7 @@ class PPSStopper(Device):
         """
         Removed limit of the PPS Stopper
         """
-        return self.summary.value == 'out'
+        return self.summary.get(as_string=True) == self.out_state
 
 
     def remove(self, **kwargs):
@@ -349,6 +365,27 @@ class PPSStopper(Device):
         """
         raise PermissionError("PPS Stopper {} can not be commanded via EPICS"
                               "".format(self.name))
+
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the PPSStopper
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            self.summary.subscribe(self._on_state_change, run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _on_state_change(self, **kwargs):
         """

--- a/tests/test_epics_attenuator.py
+++ b/tests/test_epics_attenuator.py
@@ -54,7 +54,7 @@ def test_attenuator_motion(attenuator):
 def test_attenuator_subscriptions(attenuator):
     #Subscribe a pseudo callback
     cb = Mock()
-    attenuator.subscribe(cb, run=False)
+    attenuator.subscribe(cb, event_type=attenuator.SUB_STATE,  run=False)
     #Change the target state
     attenuator.filter1.state_sig._read_pv.put(1)
     assert cb.called

--- a/tests/test_epics_ipm.py
+++ b/tests/test_epics_ipm.py
@@ -52,7 +52,7 @@ def test_ipm_motion(ipm):
 def test_ipm_subscriptions(ipm):
     #Subscribe a pseudo callback
     cb = Mock()
-    ipm.subscribe(cb, event_type=ipm.SUB_ST_CHG, run=False)
+    ipm.subscribe(cb, event_type=ipm.SUB_STATE, run=False)
     #Change the target state
     ipm.target.state._read_pv.put('OUT')
     assert cb.called

--- a/tests/test_epics_lens.py
+++ b/tests/test_epics_lens.py
@@ -45,7 +45,7 @@ def test_xfls_motion(xfls):
 def test_xfls_subscriptions(xfls):
     #Subscribe a pseudo callback
     cb = Mock()
-    xfls.subscribe(cb, run=False)
+    xfls.subscribe(cb, event_type=xfls.SUB_STATE, run=False)
     #Change readback state
     xfls.state._read_pv.put(4)
     assert cb.called

--- a/tests/test_epics_mirror.py
+++ b/tests/test_epics_mirror.py
@@ -1,6 +1,7 @@
 ############
 # Standard #
 ############
+from unittest.mock import Mock
 
 ###############
 # Third Party #
@@ -47,3 +48,12 @@ def test_branching_mirror_moves(branching_mirror):
     #Insert 
     branching_mirror.insert()
     assert branching_mirror.state.state._write_pv.value == 'IN'
+
+@using_fake_epics_pv
+def test_epics_mirror_subscription(branching_mirror):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    branching_mirror.subscribe(cb, event_type=branching_mirror.SUB_STATE, run=False)
+    #Change the target state
+    branching_mirror.state.state._read_pv.put('IN')
+    assert cb.called

--- a/tests/test_epics_pim.py
+++ b/tests/test_epics_pim.py
@@ -1,0 +1,28 @@
+############
+# Standard #
+############
+from unittest.mock import Mock
+
+###############
+# Third Party #
+###############
+import pytest
+
+##########
+# Module #
+##########
+from pcdsdevices.epics import PIMMotor
+from pcdsdevices.sim.pv import  using_fake_epics_pv
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def pim():
+    return PIMMotor('Test:Yag')
+
+
+@using_fake_epics_pv
+def test_pim_subscription(pim):
+    cb = Mock()
+    pim.subscribe(cb, event_type=pim.SUB_STATE, run=False)
+    pim.states.state._read_pv.put(4)
+    assert cb.called

--- a/tests/test_epics_pulsepicker.py
+++ b/tests/test_epics_pulsepicker.py
@@ -51,7 +51,7 @@ def test_pickerblade_motion(pickerblade):
 def test_pickerblade_subscriptions(pickerblade):
     #Subscribe a pseudo callback
     cb = Mock()
-    pickerblade.subscribe(cb, run=False)
+    pickerblade.subscribe(cb, event_type=pickerblade.SUB_STATE, run=False)
     #Change the target state
     pickerblade.simple_state._read_pv.put(1)
     assert cb.called

--- a/tests/test_epics_slits.py
+++ b/tests/test_epics_slits.py
@@ -77,7 +77,7 @@ def test_slit_transmission(slits):
 def test_slit_subscriptions(slits):
     #Subscribe a pseudo callback
     cb = Mock()
-    slits.subscribe(cb, run=False)
+    slits.subscribe(cb, event_type=slits.SUB_STATE, run=False)
     #Change the aperature size
     slits.xwidth.readback._read_pv.put(40.0)
     assert cb.called

--- a/tests/test_epics_valve.py
+++ b/tests/test_epics_valve.py
@@ -3,11 +3,12 @@
 ############
 import logging
 import time as ttime
+from unittest.mock import Mock
+
 ###############
 # Third Party #
 ###############
 import pytest
-from unittest.mock import Mock
 
 ##########
 # Module #
@@ -21,7 +22,9 @@ logger = logging.getLogger(__name__)
 @using_fake_epics_pv
 @pytest.fixture(scope='function')
 def pps():
-    return PPSStopper("PPS:H0:SUM")
+    pps = PPSStopper("PPS:H0:SUM")
+    pps.summary._read_pv.put("INCONSISTENT")
+    return pps
 
 @using_fake_epics_pv
 @pytest.fixture(scope='function')
@@ -36,11 +39,11 @@ def valve():
 @using_fake_epics_pv
 def test_pps_states(pps):
     #Removed
-    pps.summary.signal._read_pv.put(0)
+    pps.summary._read_pv.put("OUT")
     assert pps.removed
     assert not pps.inserted
     #Inserted
-    pps.summary.signal._read_pv.put(4)
+    pps.summary._read_pv.put("IN")
     assert pps.inserted
     assert not pps.removed
 
@@ -54,7 +57,7 @@ def test_pps_subscriptions(pps):
     cb = Mock()
     pps.subscribe(cb, event_type=pps.SUB_STATE, run=False)
     #Change readback state
-    pps.summary.signal._read_pv.put(4)
+    pps.summary._read_pv.put(4)
     assert cb.called
 
 

--- a/tests/test_epics_valve.py
+++ b/tests/test_epics_valve.py
@@ -52,7 +52,7 @@ def test_pps_states(pps):
 def test_pps_subscriptions(pps):
     #Subscribe a pseudo callback
     cb = Mock()
-    pps.subscribe(cb, run=False)
+    pps.subscribe(cb, event_type=pps.SUB_STATE, run=False)
     #Change readback state
     pps.summary.signal._read_pv.put(4)
     assert cb.called
@@ -103,7 +103,7 @@ def test_stopper_motion(stopper):
 def test_stopper_subscriptions(stopper):
     #Subscribe a pseudo callback
     cb = Mock()
-    stopper.subscribe(cb, run=False)
+    stopper.subscribe(cb, event_type=stopper.SUB_STATE, run=False)
     #Change readback state
     stopper.limits.open_limit._read_pv.put(0)
     stopper.limits.closed_limit._read_pv.put(1)

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -63,7 +63,7 @@ def test_remove(lodcm):
 @using_fake_epics_pv
 def test_subscribe(lodcm):
     cb = Mock()
-    lodcm.subscribe(cb, run=False)
+    lodcm.subscribe(cb, event_type=lodcm.SUB_STATE, run=False)
     assert not cb.called
     # Change destination from main to mono and main
     lodcm.h1n.state._read_pv.put('C')


### PR DESCRIPTION
Lots of files touched, very minimal changes.

## Subscription Changes
I was having the issue that many of the lightpath subscription updates were too aggressive. This was largely because `lightpath` just uses the `default_sub`. I opted to make every lightpath device have a subscription called `SUB_STATE`, that we don't have to worry about keeping `default_sub` as a low-volume subscription and can use it for whatever is intuitive for the device.

Also, I took the opportunity to unify how the devices do subscriptions. When we first started making devices we sometimes did it as follows:

```python
class MyDevice:
      state = C(DeviceState, ':STATE')
    
      def subscribe(self, *args, **kwargs):
             self.state.subscribe(*args, **kwargs)
```
This seemed kind of hacky as that prevented us from having any other subscriptions on the device. Now I made everything use the model

```python
class MyDevice:
      state = C(DeviceState, ':STATE')
      SUB_STATE = 'sub_state_changed'
     def __init__(self, *args, **kwargs):
              super().__init__(*args, **kwargs)
              self.state.subscribe(self._on_state_change, run=False)

      def _on_state_change(self, **kwargs):
             kwargs.pop('sub_type', None)
             self._run_subs(sub_type=self.SUB_STATE, **kwargs)
```

That being said. I had to rewrite this a TON of times. I think we need to revisit having a base `LightDevice` that implements a lot of this stuff. This way we can avoid such a large PR and not have to worry about uniformity so much

Closes #31 

## Attenuator 
Also, I was having trouble with the attenuator class. For all the functions that needed to iterate over the filter components, it was referring to the `:NATT` PV. I now just cache the value under `number_of_filters`, this way we don't spam that PV. 