### PR TITLE
FIX: DAQ Class Robustness

### DIFF
--- a/pcdsdevices/daq.py
+++ b/pcdsdevices/daq.py
@@ -423,7 +423,9 @@ class Daq(FlyerInterface):
             else:
                 begin_args['events'] = events
         elif duration is not None:
-            begin_args['duration'] = duration
+            secs = int(duration)
+            nsec = int((duration - secs) * 1e9)
+            begin_args['duration'] = [secs, nsec]
         else:
             begin_args['events'] = 0  # Run until manual stop
         if controls is None:

--- a/pcdsdevices/sim/daq.py
+++ b/pcdsdevices/sim/daq.py
@@ -118,14 +118,21 @@ class SimControl:
                 else:
                     return ev / 120
         if duration is not None:
-            if isinstance(duration, list):
+            if not isinstance(duration, list):
                 raise RuntimeError('This freezes the real daq')
-            elif duration <= 0:
+            elif not len(duration) == 2:
                 raise RuntimeError('This freezes the real daq')
-            elif not isinstance(duration, int):
-                raise RuntimeError('This raises an error in the daq')
+            secs = duration[0]
+            nsec = duration[1]
+            if not isinstance(secs, int):
+                raise RuntimeError('This is bad in real daq')
+            if not isinstance(nsec, int):
+                raise RuntimeError('This is bad in real daq')
+            total_time = secs + nsec * 1e-9
+            if total_time <= 0:
+                raise RuntimeError('This freezes the real daq')
             else:
-                return duration
+                return total_time
         return None
 
     def stop(self):


### PR DESCRIPTION
- Duration arg now works
- Class will wait to be ready to begin rather than attempting to begin early and stalling forever
- Prevent user from choosing duration < 1 because these cause internal issues in pydaq... sometimes
- Prevent user from configuring during a run because this breaks the session
- Updates to sim class to reflect some things I've learned about pydaq