### PR TITLE
FIX: Light Subscription Fixes  / Remove is optional

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->

--- a/pcdsdevices/device.py
+++ b/pcdsdevices/device.py
@@ -51,13 +51,6 @@ class Device(ophyd.Device, metaclass=LightInterface):
         raise NotImplementedError
 
 
-    def remove(self, *args, **kwargs):
-        """
-        Remove the device from the beamline
-        """
-        raise NotImplementedError
-
-
 class HappiData:
     """
     Class to hold arbitrary happi data

--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -490,7 +490,7 @@ class AttenuatorBase(BasicAttenuatorBase):
     # Redefine some PV names
     energy = Component(EpicsSignalRO, ":T_CALC.VALE")
     desired_transmission = Component(EpicsSignal, ":R_DES")
-    transmission_sig = Component(EpicsSignalRO, ":R_CUR")
+    transmission_sig = Component(EpicsSignalRO, ":R_CUR", auto_monitor=True)
 
     # Add third harmonic
     user_energy_3rd = Component(EpicsSignal, ":E3DES")

--- a/pcdsdevices/epics/attenuator.py
+++ b/pcdsdevices/epics/attenuator.py
@@ -454,7 +454,8 @@ class BasicAttenuatorBase(Device):
         Blade has moved
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self,  **kwargs)
 
     def stage(self):
         self.all_in()

--- a/pcdsdevices/epics/ipm.py
+++ b/pcdsdevices/epics/ipm.py
@@ -141,8 +141,9 @@ class IPMMotors(Device):
         """
         #Avoid duplicate keywords
         kwargs.pop('sub_type', None)
+        kwargs.pop('obj', None)
         #Run subscriptions
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self,  **kwargs)
 
 
 class IPM(Device):

--- a/pcdsdevices/epics/lens.py
+++ b/pcdsdevices/epics/lens.py
@@ -105,5 +105,6 @@ class XFLS(Device):
         """
         #Avoid duplicate keywords
         kwargs.pop('sub_type', None)
+        kwargs.pop('obj', None)
         #Run subscriptions
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -1078,4 +1078,5 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         Callback run on state change
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -663,6 +663,8 @@ class OffsetMirror(Device, PositionerBase):
     motor_stop = Component(Signal, value=0)
     #Transmission for Lightpath Interface
     transmission= 1.0
+    SUB_STATE = 'sub_state_changed'
+
     def __init__(self, prefix, prefix_xy, *, name=None, read_attrs=None,
                  parent=None, configuration_attrs=None, settle_time=0,
                  tolerance=0.5, timeout=None, nominal_position=None,
@@ -977,8 +979,6 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     mps = FormattedComponent(MPS, '{self._mps_prefix}', veto=True)
     #State Information
     state = FormattedComponent(InOutStates, '{self._state_prefix}')
-
-    SUB_STATE = 'sub_state_changed'
 
     def __init__(self, *args, mps_prefix=None, state_prefix=None, out_lines=None,
                  in_lines=None, **kwargs):

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -997,14 +997,14 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         """
         Whether PointingMirror is inserted
         """
-        return bool(self.state.in_state.at_state.get(as_string=False))
+        return bool(self.state.in_state.at_state.value)
 
     @property
     def removed(self):
         """
         Whether PointingMirror is removed
         """
-        return bool(self.state.out_state.at_state.get(as_string=False))
+        return bool(self.state.out_state.at_state.value)
 
     def remove(self, wait=False, timeout=None): 
         """

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -997,14 +997,14 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
         """
         Whether PointingMirror is inserted
         """
-        return bool(self.state.in_state.at_state.value)
+        return bool(int(self.state.in_state.at_state.value))
 
     @property
     def removed(self):
         """
         Whether PointingMirror is removed
         """
-        return bool(self.state.out_state.at_state.value)
+        return bool(int(self.state.out_state.at_state.value))
 
     def remove(self, wait=False, timeout=None): 
         """

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -245,8 +245,17 @@ class PIMMotor(Device, PositionerBase):
         return self.move("OUT", wait=wait, **kwargs)
 
     #Conform to lightpath interface
-    remove = move_out
-    insert = move_in
+    def insert(self, *args, **kwargs):
+        """
+        Alias for :meth:`.move_in` for lightpath interface
+        """
+        return self.move_in(*args, kwargs)
+
+    def remove(self, *args, **kwargs):
+        """
+        Alias for :meth:`.move_out` for lightpath interface
+        """
+        return self.move_out(*args, kwargs)
 
     def move_diode(self, wait=False, **kwargs):
         """

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -415,7 +415,8 @@ class PIMMotor(Device, PositionerBase):
         Callback run on state change
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)
 
 
 class PIM(PIMMotor):

--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -246,7 +246,7 @@ class PIMMotor(Device, PositionerBase):
 
     #Conform to lightpath interface
     remove = move_out
-
+    insert = move_in
 
     def move_diode(self, wait=False, **kwargs):
         """

--- a/pcdsdevices/epics/pulsepicker.py
+++ b/pcdsdevices/epics/pulsepicker.py
@@ -82,7 +82,8 @@ class PickerBlade(Device):
         Blade has moved
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)
 
 
 class PulsePicker(Device):

--- a/pcdsdevices/epics/slits.py
+++ b/pcdsdevices/epics/slits.py
@@ -262,5 +262,6 @@ class Slits(Device):
         """
         #Avoid duplicate keywords
         kwargs.pop('sub_type', None)
+        kwargs.pop('obj',      None)
         #Run subscriptions
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -352,22 +352,6 @@ class PPSStopper(Device):
         return self.summary.get(as_string=True) == self.out_state
 
 
-    def remove(self, **kwargs):
-        """
-        Stopper can not be controlled via EPICS
-
-        Raises
-        ------
-        PermissionError
-
-        Notes
-        -----
-        Exists to satisfy `lightpath` API
-        """
-        raise PermissionError("PPS Stopper {} can not be commanded via EPICS"
-                              "".format(self.name))
-
-
     def subscribe(self, cb, event_type=None, run=True):
         """
         Subscribe to changes of the PPSStopper

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -148,34 +148,9 @@ class Stopper(Device):
 
         return status
 
-
-    def remove(self, wait=False, timeout=None):
-        """
-        Remove the stopper from the beam
-        
-        Parameters
-        ----------
-        wait : bool, optional
-            Wait for the command to finish
-
-        timeout : float, optional
-            Default timeout to wait mark the request as a failure
-
-        Returns
-        -------
-        StateStatus:
-            Future that reports the completion of the request
-    
-        Notes
-        -----
-        Satisfies lightpath API
-
-        See Also
-        --------
-        :meth:`.Stopper.remove`
-        """
-        return self.open(wait=wait, timeout=timeout)
-
+    #Lightpath Interface
+    insert = close
+    remove = open
 
     @property
     def inserted(self):

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -219,7 +219,8 @@ class Stopper(Device):
         Callback when the limit state of the stopper changes
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)
 
 
 
@@ -392,4 +393,5 @@ class PPSStopper(Device):
         Callback run on state change
         """
         kwargs.pop('sub_type', None)
-        self._run_subs(sub_type=self.SUB_STATE, **kwargs)
+        kwargs.pop('obj', None)
+        self._run_subs(sub_type=self.SUB_STATE, obj=self, **kwargs)

--- a/pcdsdevices/epics/valve.py
+++ b/pcdsdevices/epics/valve.py
@@ -124,7 +124,7 @@ class Stopper(Device):
     def close(self, wait=False, timeout=None):
         """
         Close the stopper
-        
+ 
         Parameters
         ----------
         wait : bool, optional
@@ -149,8 +149,18 @@ class Stopper(Device):
         return status
 
     #Lightpath Interface
-    insert = close
-    remove = open
+    def insert(self, *args, **kwargs):
+        """
+        Alias for :meth:`.close` for lightpath interface
+        """
+        return self.close(*args, **kwargs)
+
+    def remove(self, *args, **kwargs):
+        """
+        Alias for :meth:`.open` for lightpath interface
+        """
+        return self.open(*args, **kwargs)
+
 
     @property
     def inserted(self):

--- a/pcdsdevices/interface.py
+++ b/pcdsdevices/interface.py
@@ -81,33 +81,6 @@ class LightInterface(ComponentMeta, abc.ABCMeta):
 
 
     @abc.abstractmethod
-    def remove(self, wait=False, timeout=None, finished_cb=None, **kwargs):
-        """
-        Remove the device from the beampath
-
-        This should remove the device completely from the beamline with no
-        potential for interaction with incoming photons.
-
-        Parameters
-        ----------
-        wait : bool, optional
-            Wait for the move to complete
-
-        timeout : float, optional
-            Maximum time to wait for move to complete
-
-        finished_cb : callable, optional
-            Callable to run when the move is complete
-
-        Returns
-        -------
-        status : ophyd.Status
-            Status object linked with completion of move
-        """
-        raise NotImplementedError
-
-
-    @abc.abstractmethod
     def subscribe(cb, event_type=None, run=False, **kwargs):
         """
         Subscribe a callback function to run when the device changes state

--- a/tests/test_epics_mirror.py
+++ b/tests/test_epics_mirror.py
@@ -29,6 +29,7 @@ def test_branching_mirror(branching_mirror):
     #Unknown
     assert branching_mirror.destination == []
     #Inserted
+    branching_mirror.state.out_state.at_state._read_pv.put(0)
     branching_mirror.state.in_state.at_state._read_pv.put(1)
     assert branching_mirror.inserted
     assert branching_mirror.destination == ['MFX', 'MEC']

--- a/tests/test_epics_valve.py
+++ b/tests/test_epics_valve.py
@@ -47,10 +47,6 @@ def test_pps_states(pps):
     assert pps.inserted
     assert not pps.removed
 
-    #Can not remove the PPS Stopper
-    with pytest.raises(PermissionError):
-        pps.remove()
-
 @using_fake_epics_pv
 def test_pps_subscriptions(pps):
     #Subscribe a pseudo callback

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -1,0 +1,48 @@
+############
+# Standard #
+############
+import logging
+import time
+###############
+# Third Party #
+###############
+import pytest
+from unittest.mock import Mock
+##########
+# Module #
+##########
+from pcdsdevices.sim.pv import using_fake_epics_pv
+from pcdsdevices.epics  import Reflaser
+
+@using_fake_epics_pv
+@pytest.fixture(scope='function')
+def ref():
+    ref = Reflaser("Test:Ref")
+    ref.state.state._read_pv.enum_strs = ['IN', 'OUT']
+    return ref
+
+@using_fake_epics_pv
+def test_ref_states(ref):
+    #Inserted
+    ref.state.state._read_pv.put("IN")
+    assert ref.inserted
+    assert not ref.removed
+    #Removed
+    ref.state.state._read_pv.put("OUT")
+    assert not ref.inserted
+    assert ref.removed
+
+@using_fake_epics_pv
+def test_ref_motion(ref):
+    ref.remove()
+    assert ref.state.state._write_pv.get() == 'OUT'
+
+@using_fake_epics_pv
+def test_ref_subscriptions(ref):
+    #Subscribe a pseudo callback
+    cb = Mock()
+    ref.subscribe(cb, event_type=ref.SUB_STATE, run=False)
+    #Change the target state
+    ref.state.state._read_pv.put('OUT')
+    assert cb.called
+


### PR DESCRIPTION
## Description 
A number of smaller bugs I found when stress testing the lightpath.

* When devices use `_run_subs` they should pass along a reference to themselves with `obj`. Prior to this, our devices would pass the signal that tripped their own subscription to be run passed as `obj`.
* `InOutDevice` needs to use `SUB_STATE` to specify which event type the lightpath should subscribe to.
* Added tests for `Reflaser` lightpath compatibility
* Remove is no longer required by the `LightInterface`. The main reason being is we do not want `remove` buttons for devices that can be removed by a single button in the lightpath. However, if we have `def remove(self): return NotImplemented`, we have to actually call the method to see if we should create the button. 
* There were a few objects using `.get` in their `inserted`, `removed` properties
* Fixed `PointingMirror` tests (not sure how these ever worked ....)
* Added Github issue and PR templates

## Motivation
All bugs were found during instability testing as well as running with https://github.com/slaclab/lightpath/pull/30

## How has this been tested?
Added a few tests and run underneath a live instantiation of the `lightpath`