### PR TITLE
FIX: Simplify LODCM inserted/removed for lightpath

### DIFF
--- a/pcdsdevices/epics/lodcm.py
+++ b/pcdsdevices/epics/lodcm.py
@@ -148,9 +148,9 @@ class LODCM(Device, metaclass=BranchingInterface):
         Returns
         -------
         inserted: bool
-            False if the diagnostics are in or if we have no destinations.
+            True if h1n is in
         """
-        return not (self.destination and self.diag_clear)
+        return not self.removed
 
     @property
     def removed(self):
@@ -158,9 +158,9 @@ class LODCM(Device, metaclass=BranchingInterface):
         Returns
         -------
         removed: bool
-            True if diagnostics are clear or if the main line is a destination.
+            True if h1n is out
         """
-        return self.diag_clear or self.main_line in self.destination
+        return self.h1n.value == "OUT"
 
     def remove(self, wait=False, timeout=None, finished_cb=None, **kwargs):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Separate the destination calculation from the inserted/removed calculation. Use only the the H1N state to pick inserted or removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lightpath needs inserted/removed to be simple and unambiguous. It can make its own decisions about how to interpret these booleans in the context of the destinations attribute.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The was only tested in an ipython session. The code is very simple. I am letting Travis take the wheel.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings updated