### PR TITLE
Minor Mirror Additions

### DIFF
--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -669,8 +669,6 @@ class OffsetMirror(Device, PositionerBase):
     """
     # Pitch Motor
     pitch = FormattedComponent(OMMotor, "{self.prefix}")
-    # Piezo Motor
-    piezo = FormattedComponent(Piezo, "PIEZO:{self._area}:{self._mirror}")
     # Gantry motors
     gan_x_p = FormattedComponent(OMMotor, "{self._prefix_xy}:X:P")
     gan_y_p = FormattedComponent(OMMotor, "{self._prefix_xy}:Y:P")
@@ -942,7 +940,6 @@ class OffsetMirror(Device, PositionerBase):
         if tmo is not None:
             tmo = float(tmo)
         self.pitch.timeout = tmo
-        self.piezo.timeout = tmo
         self.gan_x_p.timeout = tmo
         self.gan_y_p.timeout = tmo
 

--- a/pcdsdevices/epics/mirror.py
+++ b/pcdsdevices/epics/mirror.py
@@ -1027,6 +1027,9 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     def remove(self, wait=False, timeout=None): 
         """
         Remove the PointingMirror from the beamline
+
+        If the horizontal gantry is not coupled, the request will raise a
+        `RuntimeError`
         """
         if self.coupled:
             return self.state.move("OUT", wait=wait, timeout=timeout)
@@ -1036,6 +1039,9 @@ class PointingMirror(OffsetMirror, metaclass=BranchingInterface):
     def insert(self, wait=False, timeout=None):
         """
         Insert the pointing mirror into the beamline
+
+        If the horizontal gantry is not coupled, the request will raise a
+        `RuntimeError`
         """
         if self.coupled:
             return self.state.move("IN", wait=wait, timeout=timeout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Two major changes:
1) `PointingMirror.inserted` and `PointingMirror.removed` now use top-level `PointingMirror.state.value` to determine the state. Not sure why I felt the need to use the low-level one
2) Before calling `PointingMirror.remove` or `PointingMirror.insert`, we check that the horizontal gantry is coupled. I had a terrifying thought that people would be pressing this button in the lightpath and not checking the state, even though it should never be decoupled.  In reality, the proper implementation is to make a `Gantry` object, but not sure it is an immediate priority. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Was crashing the lightpath application

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was naughty and added this change to the release area to get the `lightpath` up and running. Added tests for new methods. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Notes added in docstrings