### PR TITLE
FIX: Make SUB_STATE the default sub for PIMs

### DIFF
--- a/pcdsdevices/epics/pim.py
+++ b/pcdsdevices/epics/pim.py
@@ -212,6 +212,7 @@ class PIMMotor(Device, PositionerBase):
     """
     states = FormattedComponent(PIMStates, "{self.prefix}")
     SUB_STATE = 'sub_state_changed'
+    _default_sub = SUB_STATE
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
                  name=None, parent=None, timeout=None, **kwargs):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
PIMMotor class has the default sub as readback, as per PositionerBase. I have changed this to SUB_STATE.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The readback sub is not used for this PIMMotor class. We expect the default sub to be something useful. After this change, subscriptions that do not specify a sub type will be run when the PIM state changes between YAG, DIODE, OUT, Unknown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Double-checked the spelling.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This does not need to be documented. It is largely a bug fix.