### PR TITLE
FIX: Reliable Components

### DIFF
--- a/pcdsdevices/component.py
+++ b/pcdsdevices/component.py
@@ -1,30 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import ophyd
-
-
-class Component(ophyd.Component):
-    """
-    Subclass of ophyd.Component to set lazy=True
-    """
-    def __init__(self, cls, suffix=None, *, lazy=True, trigger_value=None,
-                 add_prefix=None, doc=None, **kwargs):
-        super().__init__(cls, suffix=suffix, lazy=lazy,
-                         trigger_value=trigger_value, add_prefix=add_prefix,
-                         doc=doc, **kwargs)
-
-
-class FormattedComponent(Component, ophyd.FormattedComponent):
-    """
-    Subclass of ophyd.FormattedComponent to extend the formatting to the ioc
-    argument. This lets us handle the IocAdmin class where the basename isn't
-    necessarily related to the main pv basename.
-    """
-    def __init__(self, cls, suffix=None, *, lazy=True, trigger_value=None,
-                 add_prefix=None, doc=None, **kwargs):
-        if add_prefix is None:
-            add_prefix = ('suffix', 'write_pv')
-        super().__init__(cls, suffix=suffix, lazy=lazy,
-                         trigger_value=trigger_value, add_prefix=add_prefix,
-                         doc=doc, **kwargs)
-
+from ophyd import Component, FormattedComponent

--- a/pcdsdevices/epics/signal.py
+++ b/pcdsdevices/epics/signal.py
@@ -13,10 +13,17 @@ logger = logging.getLogger(__name__)
 
 
 class EpicsSignalBase(ophyd.signal.EpicsSignalBase, Signal):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._read_pv.get_ctrlvars()
 
 
 class EpicsSignal(ophyd.signal.EpicsSignal, EpicsSignalBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._write_pv != self._read_pv:
+            self._write_pv.get_ctrlvars()
+
     def put(self, value, force=False, connection_timeout=1.0,
             use_complete=None, **kwargs):
         logger.debug("Putting PV value of %s from %s to %s",

--- a/tests/test_base_overrides.py
+++ b/tests/test_base_overrides.py
@@ -9,17 +9,6 @@ from threading import Thread
 from pcdsdevices import component, device, signal
 
 
-def test_base_component():
-    """
-    In pcdsdevices.component.Component, the only change is that lazy is set to
-    True. Let's be thorough and make sure the flag is set.
-    """
-    class Test:
-        pass
-    comp = component.Component(Test)
-    assert(comp.lazy is True)
-
-
 def test_base_device():
     """
     pcdsdevices.device.Device is expecting to be passed a db_info kwarg with

--- a/tests/test_epics_attenuator.py
+++ b/tests/test_epics_attenuator.py
@@ -16,7 +16,9 @@ def fake_att():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return FeeAtt("Tst:ATT:")
+    att = FeeAtt("Tst:ATT:")
+    att.wait_for_connection()
+    return att
 
 
 @using_fake_epics_pv

--- a/tests/test_epics_ipm.py
+++ b/tests/test_epics_ipm.py
@@ -35,6 +35,7 @@ def fake_ipm():
     connect_rw_pvs(ipm.target.state)
     ipm.diode.state._write_pv.put('Unknown')
     ipm.target.state._write_pv.put('Unknown')
+    ipm.wait_for_connection()
     return ipm
 
 

--- a/tests/test_epics_lens.py
+++ b/tests/test_epics_lens.py
@@ -22,7 +22,9 @@ def fake_xfls():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return XFLS("TST:XFLS")
+    xfls = XFLS("TST:XFLS")
+    xfls.wait_for_connection()
+    return xfls
 
 
 @using_fake_epics_pv

--- a/tests/test_epics_mirror.py
+++ b/tests/test_epics_mirror.py
@@ -30,6 +30,7 @@ def fake_branching_mirror():
     m.state.state._write_pv.put('Unknown')
     m.state.out_state.at_state._read_pv.put(2)
     m.state.in_state.at_state._read_pv.put(2)
+    m.wait_for_connection()
     return m
 
 @using_fake_epics_pv

--- a/tests/test_epics_pim.py
+++ b/tests/test_epics_pim.py
@@ -22,7 +22,9 @@ def fake_pim():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return PIMMotor('Test:Yag')
+    pim = PIMMotor('Test:Yag')
+    pim.wait_for_connection()
+    return pim
 
 
 @using_fake_epics_pv

--- a/tests/test_epics_pulsepicker.py
+++ b/tests/test_epics_pulsepicker.py
@@ -25,7 +25,9 @@ def fake_pickerblade():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return PickerBlade("Tst:ATT:")
+    picker = PickerBlade("Tst:ATT:")
+    picker.wait_for_connection()
+    return picker
 
 
 @using_fake_epics_pv

--- a/tests/test_epics_slits.py
+++ b/tests/test_epics_slits.py
@@ -22,7 +22,9 @@ def fake_slits():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return Slits("TST:JAWS:")
+    slits = Slits("TST:JAWS:")
+    slits.wait_for_connection()
+    return slits
 
 
 @using_fake_epics_pv

--- a/tests/test_epics_valve.py
+++ b/tests/test_epics_valve.py
@@ -29,6 +29,7 @@ def fake_pps():
     """
     pps = PPSStopper("PPS:H0:SUM")
     pps.summary._read_pv.put("INCONSISTENT")
+    pps.wait_for_connection()
     return pps
 
 def fake_stopper():

--- a/tests/test_inout.py
+++ b/tests/test_inout.py
@@ -20,6 +20,7 @@ def fake_ref():
     ref = Reflaser("Test:Ref", name="test")
     ref.state.state._read_pv.enum_strs = ['Unknown', 'IN', 'OUT']
     ref.state.state._read_pv.put('Unknown')
+    ref.wait_for_connection()
     return ref
 
 @using_fake_epics_pv

--- a/tests/test_lodcm.py
+++ b/tests/test_lodcm.py
@@ -27,6 +27,7 @@ def fake_lodcm():
     lom.diode.state._read_pv.enum_strs = ['OUT', 'IN']
     lom.foil.state._read_pv.put('OUT')
     lom.foil.state._read_pv.enum_strs = ['OUT']
+    lom.wait_for_connection()
     return lom
 
 

--- a/tests/test_mps.py
+++ b/tests/test_mps.py
@@ -25,7 +25,9 @@ def fake_mps():
     using_fake_epics_pv does cleanup routines after the fixture and before the
     test, so we can't make this a fixture without destabilizing our tests.
     """
-    return MPS("TST:MPS")
+    mps = MPS("TST:MPS")
+    mps.wait_for_connection()
+    return mps
 
 
 @using_fake_epics_pv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Undo `Component` overrides. Call `get_ctrlvars` when we instantiate a signal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `Component` override used currently broken lazy=True option.
- `FormattedComponent` is obsolete, was for our defunct `IOCDevice`
- `get_ctrlvars` cannot be called in some callbacks, calling it early prevents this issue from ever happening.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Skywalker works with these.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
No need