### PR TITLE
FIX: Prevent race condition in stage by preventing a tolerance check

### DIFF
--- a/pcdsdevices/epics/areadetector/plugins.py
+++ b/pcdsdevices/epics/areadetector/plugins.py
@@ -70,7 +70,7 @@ class PluginBase(ophyd.plugins.PluginBase, ADBase):
         if self.enable not in self.stage_sigs:
             if not self.enable.connected:
                 self.enable.get()
-            set_and_wait(self.enable, 1)
+            set_and_wait(self.enable, 1, atol=0)
         ADBase.stage(self)
 
     @property


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
In `PluginBase.stage` add `atol=0` to the `set_and_wait` call for the `enable` signal.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`self.enable.get` does not guarantee that the `_write_pv` will finish connecting. The first line of `set_and_wait` accesses the `tolerance` property of the `EpicsSignalBase` class if `atol` is not provided. This raises a `DisconnectedError` unless `_read_pv` and `_write_pv` are both connected. We sidestep this by providing the correct tolerance, which is 0 in the case of the `enable` enum. There are no longer any issues because the `put` command that comes next will wait for the connection.

I think there needs to be an ophyd PR to really fix the issue, but this is a very easy fix now that will never get us into trouble later.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes tests and allows the skywalker stuff to run