### PR TITLE
BLD: Make ophyd version more flexible

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3
-    - ophyd ==1.0.0
+    - ophyd >=1.0.0,<1.1
     - happi <=0.5.0
 
 test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Rather than pinning specifically 1.0.0, let's also allow 1.0.1, 1.0.2...
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This gives us some flexibility in the recipe as bugs get fixed in ophyd. We still need to manually evaluate releases like 1.1.0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
conda build